### PR TITLE
feat(patchset): add multi-file patch parsing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,7 @@ mod apply;
 mod diff;
 mod merge;
 mod patch;
+mod patchset;
 mod range;
 mod utils;
 
@@ -230,3 +231,4 @@ pub use apply::{apply, apply_bytes, ApplyError};
 pub use diff::{create_patch, create_patch_bytes, DiffOptions};
 pub use merge::{merge, merge_bytes, ConflictStyle, MergeOptions};
 pub use patch::{Hunk, HunkRange, Line, ParsePatchError, Patch, PatchFormatter};
+pub use patchset::{FileOperation, FilePatch, PatchSet};

--- a/src/patch/parse.rs
+++ b/src/patch/parse.rs
@@ -17,7 +17,7 @@ type Result<T, E = ParsePatchError> = std::result::Result<T, E>;
 pub struct ParsePatchError(Cow<'static, str>);
 
 impl ParsePatchError {
-    fn new<E: Into<Cow<'static, str>>>(e: E) -> Self {
+    pub(crate) fn new<E: Into<Cow<'static, str>>>(e: E) -> Self {
         Self(e.into())
     }
 }

--- a/src/patchset/mod.rs
+++ b/src/patchset/mod.rs
@@ -1,0 +1,215 @@
+//! Utilities for parsing unified diff patches containing multiple files.
+//!
+//! This module provides [`PatchSet`] for parsing patches that contain changes
+//! to multiple files, like the output of `git diff` or `git format-patch`.
+
+mod parse;
+#[cfg(test)]
+mod tests;
+
+use crate::{ParsePatchError, Patch};
+
+/// A collection of patches for multiple files.
+///
+/// This is typically parsed from the output of `git diff` or `git format-patch`,
+/// which can contain changes to multiple files in a single patch.
+#[derive(Clone, PartialEq, Eq)]
+pub struct PatchSet<'a, T: ToOwned + ?Sized> {
+    patches: Vec<FilePatch<'a, T>>,
+}
+
+impl<T: ?Sized, O> std::fmt::Debug for PatchSet<'_, T>
+where
+    T: ToOwned<Owned = O> + std::fmt::Debug,
+    O: std::borrow::Borrow<T> + std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PatchSet")
+            .field("patches", &self.patches)
+            .finish()
+    }
+}
+
+impl<'a> PatchSet<'a, str> {
+    /// Parse a `PatchSet` from a string containing multiple file patches.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use diffy::PatchSet;
+    ///
+    /// let s = "\
+    /// --- a/file1.rs
+    /// +++ b/file1.rs
+    /// @@ -1 +1 @@
+    /// -old
+    /// +new
+    /// --- a/file2.rs
+    /// +++ b/file2.rs
+    /// @@ -1 +1 @@
+    /// -foo
+    /// +bar
+    /// ";
+    ///
+    /// let patchset = PatchSet::from_str(s).unwrap();
+    /// assert_eq!(patchset.patches().len(), 2);
+    /// ```
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &'a str) -> Result<PatchSet<'a, str>, ParsePatchError> {
+        parse::parse(s)
+    }
+}
+
+impl<'a, T: ToOwned + ?Sized> PatchSet<'a, T> {
+    pub(crate) fn new(patches: Vec<FilePatch<'a, T>>) -> Self {
+        Self { patches }
+    }
+
+    /// Returns the file patches in this patch set.
+    pub fn patches(&self) -> &[FilePatch<'a, T>] {
+        &self.patches
+    }
+
+    /// Returns an iterator over the file patches.
+    pub fn iter(&self) -> impl Iterator<Item = &FilePatch<'a, T>> {
+        self.patches.iter()
+    }
+
+    /// Returns the number of file patches.
+    pub fn len(&self) -> usize {
+        self.patches.len()
+    }
+
+    /// Returns `true` if there are no file patches.
+    pub fn is_empty(&self) -> bool {
+        self.patches.is_empty()
+    }
+}
+
+impl<'a, T: ToOwned + ?Sized> IntoIterator for PatchSet<'a, T> {
+    type Item = FilePatch<'a, T>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.patches.into_iter()
+    }
+}
+
+impl<'a, 'b, T: ToOwned + ?Sized> IntoIterator for &'b PatchSet<'a, T> {
+    type Item = &'b FilePatch<'a, T>;
+    type IntoIter = std::slice::Iter<'b, FilePatch<'a, T>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.patches.iter()
+    }
+}
+
+/// A single file's patch with operation metadata.
+///
+/// This combines a [`Patch`] with a [`FileOperation`]
+/// that indicates what kind of file operation this patch represents
+/// (create, delete, modify, or rename).
+#[derive(Clone, PartialEq, Eq)]
+pub struct FilePatch<'a, T: ToOwned + ?Sized> {
+    operation: FileOperation,
+    patch: Patch<'a, T>,
+}
+
+impl<T: ?Sized, O> std::fmt::Debug for FilePatch<'_, T>
+where
+    T: ToOwned<Owned = O> + std::fmt::Debug,
+    O: std::borrow::Borrow<T> + std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FilePatch")
+            .field("operation", &self.operation)
+            .field("patch", &self.patch)
+            .finish()
+    }
+}
+
+impl<'a, T: ToOwned + ?Sized> FilePatch<'a, T> {
+    pub(crate) fn new(operation: FileOperation, patch: Patch<'a, T>) -> Self {
+        Self { operation, patch }
+    }
+
+    /// Returns the file operation for this patch.
+    pub fn operation(&self) -> &FileOperation {
+        &self.operation
+    }
+
+    /// Returns the underlying patch.
+    pub fn patch(&self) -> &Patch<'a, T> {
+        &self.patch
+    }
+
+    /// Consumes the [`FilePatch`] and returns the underlying [`Patch`].
+    pub fn into_patch(self) -> Patch<'a, T> {
+        self.patch
+    }
+}
+
+/// The operation to perform based on a patch.
+///
+/// This is determined by examining the `---` and `+++` header lines
+/// of a unified diff patch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileOperation {
+    /// Delete a file (`+++ /dev/null`).
+    Delete(String),
+    /// Create a new file (`--- /dev/null`).
+    Create(String),
+    /// Modify or rename a file.
+    ///
+    /// * `from == to` → modify file in place
+    /// * `from != to` → rename (read from `from`, write to `to`, delete `from`)
+    Modify { from: String, to: String },
+}
+
+impl FileOperation {
+    /// Strip the first `n` path components from the paths in this operation.
+    ///
+    /// This is similar to the `-p` option in GNU patch. For example,
+    /// `strip_prefix(1)` on a path `a/src/lib.rs` would return `src/lib.rs`.
+    pub fn strip_prefix(&self, n: usize) -> FileOperation {
+        fn strip(path: &str, n: usize) -> String {
+            let mut remaining = path;
+            for _ in 0..n {
+                match remaining.split_once('/') {
+                    Some((_first, rest)) => remaining = rest,
+                    None => return remaining.to_owned(),
+                }
+            }
+            remaining.to_owned()
+        }
+
+        match self {
+            FileOperation::Delete(path) => FileOperation::Delete(strip(path, n)),
+            FileOperation::Create(path) => FileOperation::Create(strip(path, n)),
+            FileOperation::Modify { from, to } => FileOperation::Modify {
+                from: strip(from, n),
+                to: strip(to, n),
+            },
+        }
+    }
+
+    /// Returns `true` if this is a file creation operation.
+    pub fn is_create(&self) -> bool {
+        matches!(self, FileOperation::Create(_))
+    }
+
+    /// Returns `true` if this is a file deletion operation.
+    pub fn is_delete(&self) -> bool {
+        matches!(self, FileOperation::Delete(_))
+    }
+
+    /// Returns `true` if this is a file modification (including rename).
+    pub fn is_modify(&self) -> bool {
+        matches!(self, FileOperation::Modify { .. })
+    }
+
+    /// Returns `true` if this is a rename operation (modify where `from != to`).
+    pub fn is_rename(&self) -> bool {
+        matches!(self, FileOperation::Modify { from, to } if from != to)
+    }
+}

--- a/src/patchset/parse.rs
+++ b/src/patchset/parse.rs
@@ -1,0 +1,150 @@
+//! Parse multiple file patches from a unified diff.
+
+use super::{FileOperation, FilePatch, PatchSet};
+use crate::{ParsePatchError, Patch};
+
+/// Prefix for the original file path (e.g., `--- a/file.rs`).
+const ORIGINAL_PREFIX: &str = "--- ";
+/// Prefix for the modified file path (e.g., `+++ b/file.rs`).
+const MODIFIED_PREFIX: &str = "+++ ";
+/// Prefix for a hunk header (e.g., `@@ -1,3 +1,4 @@`).
+const HUNK_PREFIX: &str = "@@ ";
+/// Path used to indicate file creation or deletion.
+const DEV_NULL: &str = "/dev/null";
+
+/// Parse a multi-file patch.
+pub fn parse(input: &str) -> Result<PatchSet<'_, str>, ParsePatchError> {
+    let patch_strs = split_patches(input);
+
+    let mut patches = Vec::with_capacity(patch_strs.len());
+    for patch_str in patch_strs {
+        let patch = Patch::from_str(patch_str)?;
+        let operation = extract_file_operation(patch.original(), patch.modified())?;
+        patches.push(FilePatch::new(operation, patch));
+    }
+
+    Ok(PatchSet::new(patches))
+}
+
+/// Splits a unified diff containing multiple file patches.
+pub fn split_patches(content: &str) -> Vec<&str> {
+    let mut patches = Vec::new();
+    let mut patch_start = None::<usize>;
+    let mut prev_line = None::<&str>;
+    let mut byte_offset = 0;
+
+    let mut lines = content.lines().peekable();
+
+    while let Some(line) = lines.next() {
+        let next_line = lines.peek().copied();
+
+        if is_patch_boundary(prev_line, line, next_line) {
+            if let Some(start) = patch_start {
+                patches.push(&content[start..byte_offset]);
+            }
+            patch_start = Some(byte_offset);
+        }
+
+        prev_line = Some(line);
+        byte_offset += line.len();
+
+        if content[byte_offset..].starts_with("\r\n") {
+            byte_offset += 2;
+        } else if content[byte_offset..].starts_with('\n') {
+            byte_offset += 1;
+        }
+    }
+
+    if let Some(start) = patch_start {
+        patches.push(&content[start..]);
+    }
+
+    patches
+}
+
+/// Checks if the current line is a patch boundary.
+///
+/// A patch boundary is one of:
+///
+/// - `--- ` followed by `+++ ` on the next line
+/// - `+++ ` followed by `--- ` on the next line
+/// - `--- ` followed by `@@ ` on the next line (missing `+++`)
+/// - `+++ ` followed by `@@ ` on the next line (missing `---`)
+fn is_patch_boundary(prev: Option<&str>, line: &str, next: Option<&str>) -> bool {
+    if line.starts_with(ORIGINAL_PREFIX) {
+        // Make sure it isn't part of a (`+++` / `--- `) pair
+        if prev.map_or(false, |p| p.starts_with(MODIFIED_PREFIX)) {
+            return false;
+        }
+        // `--- ` followed by `+++ `
+        if next.map_or(false, |n| n.starts_with(MODIFIED_PREFIX)) {
+            return true;
+        }
+        // `--- ` followed by `@@ `
+        if next.map_or(false, |n| n.starts_with(HUNK_PREFIX)) {
+            return true;
+        }
+    }
+
+    if line.starts_with(MODIFIED_PREFIX) {
+        // Make sure it isn't part of a (`---` / `+++`) pair
+        if prev.map_or(false, |p| p.starts_with(ORIGINAL_PREFIX)) {
+            return false;
+        }
+        // `+++ ` followed by `--- `
+        if next.map_or(false, |n| n.starts_with(ORIGINAL_PREFIX)) {
+            return true;
+        }
+        // `+++ ` followed by `@@ `
+        if next.map_or(false, |n| n.starts_with(HUNK_PREFIX)) {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// Extracts the file operation from a patch based on its header paths.
+pub fn extract_file_operation(
+    original: Option<&str>,
+    modified: Option<&str>,
+) -> Result<FileOperation, ParsePatchError> {
+    let is_create = original == Some(DEV_NULL);
+    let is_delete = modified == Some(DEV_NULL);
+
+    if is_create && is_delete {
+        return Err(ParsePatchError::new(
+            "patch has both original and modified as /dev/null",
+        ));
+    }
+
+    if is_delete {
+        let path =
+            original.ok_or_else(|| ParsePatchError::new("delete patch has no original path"))?;
+        Ok(FileOperation::Delete(path.to_owned()))
+    } else if is_create {
+        let path =
+            modified.ok_or_else(|| ParsePatchError::new("create patch has no modified path"))?;
+        Ok(FileOperation::Create(path.to_owned()))
+    } else {
+        match (original, modified) {
+            (Some(from), Some(to)) => Ok(FileOperation::Modify {
+                from: from.to_owned(),
+                to: to.to_owned(),
+            }),
+            (None, Some(to)) => {
+                // No original path, but has modified path.
+                // This is a modify operation (not create) - GNU patch reads from the modified path.
+                Ok(FileOperation::Modify {
+                    from: to.to_owned(),
+                    to: to.to_owned(),
+                })
+            }
+            (Some(from), None) => Ok(FileOperation::Modify {
+                from: from.to_owned(),
+                to: from.to_owned(),
+            }),
+            (None, None) => Err(ParsePatchError::new("patch has no file path")),
+        }
+    }
+}

--- a/src/patchset/tests.rs
+++ b/src/patchset/tests.rs
@@ -1,0 +1,384 @@
+//! Tests for patchset parsing.
+
+use super::parse::{extract_file_operation, split_patches};
+use super::{FileOperation, PatchSet};
+use crate::Patch;
+
+mod file_operation {
+    use super::*;
+
+    #[test]
+    fn test_strip_prefix() {
+        let op = FileOperation::Modify {
+            from: "a/src/lib.rs".to_owned(),
+            to: "b/src/lib.rs".to_owned(),
+        };
+        let stripped = op.strip_prefix(1);
+        assert_eq!(
+            stripped,
+            FileOperation::Modify {
+                from: "src/lib.rs".to_owned(),
+                to: "src/lib.rs".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_strip_prefix_no_slash() {
+        let op = FileOperation::Create("file.rs".to_owned());
+        let stripped = op.strip_prefix(1);
+        assert_eq!(stripped, FileOperation::Create("file.rs".to_owned()));
+    }
+
+    #[test]
+    fn test_is_rename() {
+        let modify_same = FileOperation::Modify {
+            from: "file.rs".to_owned(),
+            to: "file.rs".to_owned(),
+        };
+        assert!(!modify_same.is_rename());
+
+        let rename = FileOperation::Modify {
+            from: "old.rs".to_owned(),
+            to: "new.rs".to_owned(),
+        };
+        assert!(rename.is_rename());
+    }
+}
+
+mod split_patches {
+    use super::*;
+
+    #[test]
+    fn single_file_patch() {
+        let content = "\
+--- a/file.rs
++++ b/file.rs
+@@ -1,3 +1,4 @@
+ line1
+ line2
++line3
+ line4
+";
+        let patches = split_patches(content);
+        assert_eq!(patches.len(), 1);
+        assert!(Patch::from_str(patches[0]).is_ok());
+    }
+
+    #[test]
+    fn multi_file_patch() {
+        let content = "\
+--- a/file1.rs
++++ b/file1.rs
+@@ -1 +1 @@
+-old1
++new1
+--- a/file2.rs
++++ b/file2.rs
+@@ -1 +1 @@
+-old2
++new2
+";
+        let patches = split_patches(content);
+        assert_eq!(patches.len(), 2);
+        assert!(Patch::from_str(patches[0]).is_ok());
+        assert!(Patch::from_str(patches[1]).is_ok());
+    }
+
+    #[test]
+    fn patch_with_preamble() {
+        let content = "\
+This is a preamble
+It should be ignored
+--- a/file.rs
++++ b/file.rs
+@@ -1 +1 @@
+-old
++new
+";
+        let patches = split_patches(content);
+        assert_eq!(patches.len(), 1);
+        assert!(Patch::from_str(patches[0]).is_ok());
+    }
+
+    #[test]
+    fn ignores_false_positive() {
+        // line starting with "--- " but not a patch boundary
+        let content = "\
+--- a/file.rs
++++ b/file.rs
+@@ -1,3 +1,3 @@
+ line1
+---- this is not a patch boundary
++--- this line starts with dashes
+ line3
+";
+        let patches = split_patches(content);
+        assert_eq!(patches.len(), 1);
+        assert!(Patch::from_str(patches[0]).is_ok());
+    }
+
+    #[test]
+    fn split_empty_content() {
+        let patches = split_patches("");
+        assert!(patches.is_empty());
+    }
+
+    #[test]
+    fn git_format_patch() {
+        let content = "\
+From 1234567890abcdef1234567890abcdef12345678 Mon Sep 17 00:00:00 2001
+From: Gandalf <gandarf@the.grey>
+Date: Mon, 25 Mar 3019 00:00:00 +0000
+Subject: [PATCH] fix!: destroy the one ring at mount doom
+
+In a hole in the ground there lived a hobbit
+---
+ src/frodo.rs | 2 +-
+ src/sam.rs   | 1 +
+ 2 files changed, 2 insertions(+), 1 deletion(-)
+
+--- a/src/frodo.rs
++++ b/src/frodo.rs
+@@ -1 +1 @@
+-finger
++peace
+--- a/src/sam.rs
++++ b/src/sam.rs
+@@ -1 +1,2 @@
+ food
++more food
+--
+2.40.0
+";
+        let patches = split_patches(content);
+        assert_eq!(patches.len(), 2);
+        assert!(Patch::from_str(patches[0]).is_ok());
+        // Last patch has trailing content `--\n2.40.0` that diffy rejects
+        assert!(Patch::from_str(patches[1]).is_err());
+    }
+
+    #[test]
+    fn not_a_patch() {
+        let content = "Some random text\nNo patches here\n";
+        let patches = split_patches(content);
+        assert!(patches.is_empty());
+    }
+
+    #[test]
+    fn incomplete_header() {
+        // Has --- but no following +++ or @@
+        let content = "\
+--- a/file.rs
+Some random text
+No patches here
+";
+        let patches = split_patches(content);
+        assert!(patches.is_empty());
+    }
+
+    #[test]
+    fn missing_modified_header() {
+        let content = "\
+--- a/file.rs
+@@ -1 +1 @@
+-old
++new
+";
+        let patches = split_patches(content);
+        assert_eq!(patches.len(), 1);
+        assert!(Patch::from_str(patches[0]).is_ok());
+    }
+
+    #[test]
+    fn missing_original_header() {
+        let content = "\
++++ b/file.rs
+@@ -1 +1 @@
+-old
++new
+";
+        let patches = split_patches(content);
+        assert_eq!(patches.len(), 1);
+        assert!(Patch::from_str(patches[0]).is_ok());
+    }
+
+    #[test]
+    fn reversed_header_order() {
+        let content = "\
++++ b/file.rs
+--- a/file.rs
+@@ -1 +1 @@
+-old
++new
+";
+        let patches = split_patches(content);
+        assert_eq!(patches.len(), 1);
+        assert!(Patch::from_str(patches[0]).is_ok());
+    }
+
+    #[test]
+    fn multi_file_mixed_headers() {
+        let content = "\
+--- a/file1.rs
++++ b/file1.rs
+@@ -1 +1 @@
+-old1
++new1
+--- a/file2.rs
+@@ -1 +1 @@
+-old2
++new2
++++ b/file3.rs
+@@ -1 +1 @@
+-old3
++new3
+";
+        let patches = split_patches(content);
+        assert_eq!(patches.len(), 3);
+        assert!(Patch::from_str(patches[0]).is_ok());
+        assert!(Patch::from_str(patches[1]).is_ok());
+        assert!(Patch::from_str(patches[2]).is_ok());
+    }
+}
+
+mod extract_file_operation {
+    use super::*;
+
+    #[test]
+    fn modify() {
+        let op = extract_file_operation(Some("a/src/lib.rs"), Some("b/src/lib.rs")).unwrap();
+        assert_eq!(
+            op,
+            FileOperation::Modify {
+                from: "a/src/lib.rs".to_owned(),
+                to: "b/src/lib.rs".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn new_file() {
+        let op = extract_file_operation(Some("/dev/null"), Some("b/src/lib.rs")).unwrap();
+        assert_eq!(op, FileOperation::Create("b/src/lib.rs".to_owned()));
+    }
+
+    #[test]
+    fn delete_file() {
+        let op = extract_file_operation(Some("a/src/lib.rs"), Some("/dev/null")).unwrap();
+        assert_eq!(op, FileOperation::Delete("a/src/lib.rs".to_owned()));
+    }
+
+    #[test]
+    fn rename() {
+        let op = extract_file_operation(Some("a/old_name.rs"), Some("b/new_name.rs")).unwrap();
+        assert_eq!(
+            op,
+            FileOperation::Modify {
+                from: "a/old_name.rs".to_owned(),
+                to: "b/new_name.rs".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn missing_modified_uses_original() {
+        let op = extract_file_operation(Some("a/src/lib.rs"), None).unwrap();
+        assert_eq!(
+            op,
+            FileOperation::Modify {
+                from: "a/src/lib.rs".to_owned(),
+                to: "a/src/lib.rs".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn missing_original_uses_modified() {
+        let op = extract_file_operation(None, Some("b/src/lib.rs")).unwrap();
+        assert_eq!(
+            op,
+            FileOperation::Modify {
+                from: "b/src/lib.rs".to_owned(),
+                to: "b/src/lib.rs".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn both_dev_null_errors() {
+        let result = extract_file_operation(Some("/dev/null"), Some("/dev/null"));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn missing_both_paths_errors() {
+        let result = extract_file_operation(None, None);
+        assert!(result.is_err());
+    }
+}
+
+mod patchset {
+    use super::*;
+
+    #[test]
+    fn patchset_from_str() {
+        let content = "\
+--- a/file1.rs
++++ b/file1.rs
+@@ -1 +1 @@
+-old1
++new1
+--- a/file2.rs
++++ b/file2.rs
+@@ -1 +1 @@
+-old2
++new2
+";
+        let patchset = PatchSet::from_str(content).unwrap();
+        assert_eq!(patchset.len(), 2);
+
+        let patch1 = &patchset.patches()[0];
+        assert!(patch1.operation().is_modify());
+        assert_eq!(patch1.patch().original(), Some("a/file1.rs"));
+
+        let patch2 = &patchset.patches()[1];
+        assert!(patch2.operation().is_modify());
+        assert_eq!(patch2.patch().original(), Some("a/file2.rs"));
+    }
+
+    #[test]
+    fn patchset_create_delete() {
+        let content = "\
+--- /dev/null
++++ b/new_file.rs
+@@ -0,0 +1 @@
++content
+--- a/old_file.rs
++++ /dev/null
+@@ -1 +0,0 @@
+-content
+";
+        let patchset = PatchSet::from_str(content).unwrap();
+        assert_eq!(patchset.len(), 2);
+
+        assert!(patchset.patches()[0].operation().is_create());
+        assert!(patchset.patches()[1].operation().is_delete());
+    }
+
+    #[test]
+    fn patchset_rename() {
+        let content = "\
+--- a/old_name.rs
++++ b/new_name.rs
+@@ -1 +1 @@
+-old
++new
+";
+        let patchset = PatchSet::from_str(content).unwrap();
+        assert_eq!(patchset.len(), 1);
+
+        let op = patchset.patches()[0].operation();
+        assert!(op.is_rename());
+    }
+}


### PR DESCRIPTION
Add `PatchSet` for parsing unified diffs containing multiple files, like the output of `git diff` or `git format-patch`.

Currently supports:

* multiple file patches
* modify files
* rename files
* create files (`--- /dev/null`)
* delete files (`+++ /dev/null`)
* strip path components (like `patch -p1`)