### PR TITLE
fix(patch)!: migrate to anstyle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [stable, beta, nightly, 1.62.1]
+        rust: [stable, beta, nightly, 1.70.0]
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - run: rustup toolchain install ${{ matrix.rust }} --profile minimal
+      - run: cargo +${{ matrix.rust }} check --all-targets --all-features
       - run: cargo +${{ matrix.rust }} test
 
   lint:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/bmwill/diffy"
 readme = "README.md"
 keywords = ["diff", "patch", "merge"]
 categories = ["text-processing"]
-rust-version = "1.62.1"
+rust-version = "1.70.0"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ rust-version = "1.70.0"
 edition = "2021"
 
 [dependencies]
-nu-ansi-term = "0.50"
+anstyle = "1.0.13"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,12 @@ categories = ["text-processing"]
 rust-version = "1.70.0"
 edition = "2021"
 
+[features]
+color = ["dep:anstyle"]
+
 [dependencies]
-anstyle = "1.0.13"
+anstyle = { version = "1.0.13", optional = true }
+
+[[example]]
+name = "patch_formatter"
+required-features = ["color"]

--- a/examples/patch_formatter.rs
+++ b/examples/patch_formatter.rs
@@ -1,0 +1,26 @@
+use diffy::create_patch;
+use diffy::PatchFormatter;
+
+fn main() {
+    let original = "first line\nlast line";
+    let modified = "first line\nmodified last line";
+
+    let patch = create_patch(original, modified);
+
+    println!("PatchFormatter::Default");
+    println!("{patch}");
+
+    let formatter = PatchFormatter::new().missing_newline_message(false);
+    println!("{formatter:?}");
+    println!("{}", formatter.fmt_patch(&patch));
+
+    let formatter = PatchFormatter::new().with_color();
+    println!("{formatter:?}");
+    println!("{}", formatter.fmt_patch(&patch));
+
+    let formatter = PatchFormatter::new()
+        .with_color()
+        .missing_newline_message(false);
+    println!("{formatter:?}");
+    println!("{}", formatter.fmt_patch(&patch));
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@
 //!
 //! A [`Patch`] can the be output in the [Unified Format] either by using its
 //! [`Display`] impl or by using a [`PatchFormatter`] to output the diff with
-//! color.
+//! color (requires the `color` feature).
 //!
 //! ```
 //! # use diffy::create_patch;
@@ -73,9 +73,12 @@
 //! #
 //! // Without color
 //! print!("{}", patch);
+//! ```
 //!
-//! // With color
-//! # use diffy::PatchFormatter;
+//! With the `color` feature enabled:
+//!
+//! ```ignore
+//! use diffy::PatchFormatter;
 //! let f = PatchFormatter::new().with_color();
 //! print!("{}", f.fmt_patch(&patch));
 //! ```

--- a/src/patch/format.rs
+++ b/src/patch/format.rs
@@ -1,9 +1,10 @@
-use super::{Hunk, Line, Patch, NO_NEWLINE_AT_EOF};
-use nu_ansi_term::{Color, Style};
 use std::{
     fmt::{Display, Formatter, Result},
     io,
 };
+
+use super::style;
+use super::{Hunk, Line, Patch, NO_NEWLINE_AT_EOF};
 
 /// Struct used to adjust the formatting of a `Patch`
 #[derive(Debug)]
@@ -11,13 +12,6 @@ pub struct PatchFormatter {
     with_color: bool,
     with_missing_newline_message: bool,
     suppress_blank_empty: bool,
-
-    context: Style,
-    delete: Style,
-    insert: Style,
-    hunk_header: Style,
-    patch_header: Style,
-    function_context: Style,
 }
 
 impl PatchFormatter {
@@ -30,13 +24,6 @@ impl PatchFormatter {
             // TODO the default in git-diff and GNU diff is to have this set to false, on the next
             // semver breaking release we should contemplate switching this to be false by default
             suppress_blank_empty: true,
-
-            context: Style::new(),
-            delete: Color::Red.normal(),
-            insert: Color::Green.normal(),
-            hunk_header: Color::Cyan.normal(),
-            patch_header: Style::new().bold(),
-            function_context: Style::new(),
         }
     }
 
@@ -125,8 +112,9 @@ struct PatchDisplay<'a, T: ToOwned + ?Sized> {
 impl<T: ToOwned + AsRef<[u8]> + ?Sized> PatchDisplay<'_, T> {
     fn write_into<W: io::Write>(&self, mut w: W) -> io::Result<()> {
         if self.patch.original.is_some() || self.patch.modified.is_some() {
+            let style = style::PATCH_HEADER;
             if self.f.with_color {
-                write!(w, "{}", self.f.patch_header.prefix())?;
+                write!(w, "{style}")?;
             }
             if let Some(original) = &self.patch.original {
                 write!(w, "--- ")?;
@@ -139,7 +127,7 @@ impl<T: ToOwned + AsRef<[u8]> + ?Sized> PatchDisplay<'_, T> {
                 writeln!(w)?;
             }
             if self.f.with_color {
-                write!(w, "{}", self.f.patch_header.suffix())?;
+                write!(w, "{style:#}")?;
             }
         }
 
@@ -154,8 +142,9 @@ impl<T: ToOwned + AsRef<[u8]> + ?Sized> PatchDisplay<'_, T> {
 impl Display for PatchDisplay<'_, str> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         if self.patch.original.is_some() || self.patch.modified.is_some() {
+            let style = style::PATCH_HEADER;
             if self.f.with_color {
-                write!(f, "{}", self.f.patch_header.prefix())?;
+                write!(f, "{style}")?;
             }
             if let Some(original) = &self.patch.original {
                 writeln!(f, "--- {}", original)?;
@@ -164,7 +153,7 @@ impl Display for PatchDisplay<'_, str> {
                 writeln!(f, "+++ {}", modified)?;
             }
             if self.f.with_color {
-                write!(f, "{}", self.f.patch_header.suffix())?;
+                write!(f, "{style:#}")?;
             }
         }
 
@@ -183,23 +172,25 @@ struct HunkDisplay<'a, T: ?Sized> {
 
 impl<T: AsRef<[u8]> + ?Sized> HunkDisplay<'_, T> {
     fn write_into<W: io::Write>(&self, mut w: W) -> io::Result<()> {
+        let style = style::HUNK_HEADER;
         if self.f.with_color {
-            write!(w, "{}", self.f.hunk_header.prefix())?;
+            write!(w, "{style}")?;
         }
         write!(w, "@@ -{} +{} @@", self.hunk.old_range, self.hunk.new_range)?;
         if self.f.with_color {
-            write!(w, "{}", self.f.hunk_header.suffix())?;
+            write!(w, "{style:#}")?;
         }
 
         if let Some(ctx) = self.hunk.function_context {
+            let style = style::FUNCTION_CONTEXT;
             write!(w, " ")?;
             if self.f.with_color {
-                write!(w, "{}", self.f.function_context.prefix())?;
+                write!(w, "{style}")?;
             }
             write!(w, " ")?;
             w.write_all(ctx.as_ref())?;
             if self.f.with_color {
-                write!(w, "{}", self.f.function_context.suffix())?;
+                write!(w, "{style:#}")?;
             }
         }
         writeln!(w)?;
@@ -214,22 +205,24 @@ impl<T: AsRef<[u8]> + ?Sized> HunkDisplay<'_, T> {
 
 impl Display for HunkDisplay<'_, str> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        let style = style::HUNK_HEADER;
         if self.f.with_color {
-            write!(f, "{}", self.f.hunk_header.prefix())?;
+            write!(f, "{style}")?;
         }
         write!(f, "@@ -{} +{} @@", self.hunk.old_range, self.hunk.new_range)?;
         if self.f.with_color {
-            write!(f, "{}", self.f.hunk_header.suffix())?;
+            write!(f, "{style:#}")?;
         }
 
         if let Some(ctx) = self.hunk.function_context {
+            let style = style::FUNCTION_CONTEXT;
             write!(f, " ")?;
             if self.f.with_color {
-                write!(f, "{}", self.f.function_context.prefix())?;
+                write!(f, "{style}")?;
             }
             write!(f, " {}", ctx)?;
             if self.f.with_color {
-                write!(f, "{}", self.f.function_context.suffix())?;
+                write!(f, "{style:#}")?;
             }
         }
         writeln!(f)?;
@@ -250,13 +243,13 @@ struct LineDisplay<'a, T: ?Sized> {
 impl<T: AsRef<[u8]> + ?Sized> LineDisplay<'_, T> {
     fn write_into<W: io::Write>(&self, mut w: W) -> io::Result<()> {
         let (sign, line, style) = match self.line {
-            Line::Context(line) => (' ', line.as_ref(), self.f.context),
-            Line::Delete(line) => ('-', line.as_ref(), self.f.delete),
-            Line::Insert(line) => ('+', line.as_ref(), self.f.insert),
+            Line::Context(line) => (' ', line.as_ref(), style::CONTEXT),
+            Line::Delete(line) => ('-', line.as_ref(), style::DELETE),
+            Line::Insert(line) => ('+', line.as_ref(), style::INSERT),
         };
 
         if self.f.with_color {
-            write!(w, "{}", style.prefix())?;
+            write!(w, "{style}")?;
         }
 
         if self.f.suppress_blank_empty && sign == ' ' && line == b"\n" {
@@ -267,7 +260,7 @@ impl<T: AsRef<[u8]> + ?Sized> LineDisplay<'_, T> {
         }
 
         if self.f.with_color {
-            write!(w, "{}", style.suffix())?;
+            write!(w, "{style:#}")?;
         }
 
         if !line.ends_with(b"\n") {
@@ -284,13 +277,13 @@ impl<T: AsRef<[u8]> + ?Sized> LineDisplay<'_, T> {
 impl Display for LineDisplay<'_, str> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let (sign, line, style) = match self.line {
-            Line::Context(line) => (' ', line, self.f.context),
-            Line::Delete(line) => ('-', line, self.f.delete),
-            Line::Insert(line) => ('+', line, self.f.insert),
+            Line::Context(line) => (' ', line, style::CONTEXT),
+            Line::Delete(line) => ('-', line, style::DELETE),
+            Line::Insert(line) => ('+', line, style::INSERT),
         };
 
         if self.f.with_color {
-            write!(f, "{}", style.prefix())?;
+            write!(f, "{style}")?;
         }
 
         if self.f.suppress_blank_empty && sign == ' ' && *line == "\n" {
@@ -300,7 +293,7 @@ impl Display for LineDisplay<'_, str> {
         }
 
         if self.f.with_color {
-            write!(f, "{}", style.suffix())?;
+            write!(f, "{style:#}")?;
         }
 
         if !line.ends_with('\n') {

--- a/src/patch/format.rs
+++ b/src/patch/format.rs
@@ -182,16 +182,8 @@ impl<T: AsRef<[u8]> + ?Sized> HunkDisplay<'_, T> {
         }
 
         if let Some(ctx) = self.hunk.function_context {
-            let style = style::FUNCTION_CONTEXT;
-            write!(w, " ")?;
-            if self.f.with_color {
-                write!(w, "{style}")?;
-            }
-            write!(w, " ")?;
+            write!(w, "  ")?;
             w.write_all(ctx.as_ref())?;
-            if self.f.with_color {
-                write!(w, "{style:#}")?;
-            }
         }
         writeln!(w)?;
 
@@ -215,15 +207,7 @@ impl Display for HunkDisplay<'_, str> {
         }
 
         if let Some(ctx) = self.hunk.function_context {
-            let style = style::FUNCTION_CONTEXT;
-            write!(f, " ")?;
-            if self.f.with_color {
-                write!(f, "{style}")?;
-            }
-            write!(f, " {}", ctx)?;
-            if self.f.with_color {
-                write!(f, "{style:#}")?;
-            }
+            write!(f, "  {}", ctx)?;
         }
         writeln!(f)?;
 
@@ -243,12 +227,12 @@ struct LineDisplay<'a, T: ?Sized> {
 impl<T: AsRef<[u8]> + ?Sized> LineDisplay<'_, T> {
     fn write_into<W: io::Write>(&self, mut w: W) -> io::Result<()> {
         let (sign, line, style) = match self.line {
-            Line::Context(line) => (' ', line.as_ref(), style::CONTEXT),
-            Line::Delete(line) => ('-', line.as_ref(), style::DELETE),
-            Line::Insert(line) => ('+', line.as_ref(), style::INSERT),
+            Line::Context(line) => (' ', line.as_ref(), None),
+            Line::Delete(line) => ('-', line.as_ref(), Some(style::DELETE)),
+            Line::Insert(line) => ('+', line.as_ref(), Some(style::INSERT)),
         };
 
-        if self.f.with_color {
+        if let (true, Some(style)) = (self.f.with_color, style) {
             write!(w, "{style}")?;
         }
 
@@ -259,7 +243,7 @@ impl<T: AsRef<[u8]> + ?Sized> LineDisplay<'_, T> {
             w.write_all(line)?;
         }
 
-        if self.f.with_color {
+        if let (true, Some(style)) = (self.f.with_color, style) {
             write!(w, "{style:#}")?;
         }
 
@@ -277,12 +261,12 @@ impl<T: AsRef<[u8]> + ?Sized> LineDisplay<'_, T> {
 impl Display for LineDisplay<'_, str> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let (sign, line, style) = match self.line {
-            Line::Context(line) => (' ', line, style::CONTEXT),
-            Line::Delete(line) => ('-', line, style::DELETE),
-            Line::Insert(line) => ('+', line, style::INSERT),
+            Line::Context(line) => (' ', line, None),
+            Line::Delete(line) => ('-', line, Some(style::DELETE)),
+            Line::Insert(line) => ('+', line, Some(style::INSERT)),
         };
 
-        if self.f.with_color {
+        if let (true, Some(style)) = (self.f.with_color, style) {
             write!(f, "{style}")?;
         }
 
@@ -292,7 +276,7 @@ impl Display for LineDisplay<'_, str> {
             write!(f, "{}{}", sign, line)?;
         }
 
-        if self.f.with_color {
+        if let (true, Some(style)) = (self.f.with_color, style) {
             write!(f, "{style:#}")?;
         }
 

--- a/src/patch/format.rs
+++ b/src/patch/format.rs
@@ -147,10 +147,10 @@ impl Display for PatchDisplay<'_, str> {
                 write!(f, "{style}")?;
             }
             if let Some(original) = &self.patch.original {
-                writeln!(f, "--- {}", original)?;
+                writeln!(f, "--- {original}")?;
             }
             if let Some(modified) = &self.patch.modified {
-                writeln!(f, "+++ {}", modified)?;
+                writeln!(f, "+++ {modified}")?;
             }
             if self.f.with_color {
                 write!(f, "{style:#}")?;
@@ -207,7 +207,7 @@ impl Display for HunkDisplay<'_, str> {
         }
 
         if let Some(ctx) = self.hunk.function_context {
-            write!(f, "  {}", ctx)?;
+            write!(f, "  {ctx}")?;
         }
         writeln!(f)?;
 
@@ -227,30 +227,30 @@ struct LineDisplay<'a, T: ?Sized> {
 impl<T: AsRef<[u8]> + ?Sized> LineDisplay<'_, T> {
     fn write_into<W: io::Write>(&self, mut w: W) -> io::Result<()> {
         let (sign, line, style) = match self.line {
-            Line::Context(line) => (' ', line.as_ref(), None),
-            Line::Delete(line) => ('-', line.as_ref(), Some(style::DELETE)),
-            Line::Insert(line) => ('+', line.as_ref(), Some(style::INSERT)),
+            Line::Context(line) => (' ', line.as_ref(), style::NOP),
+            Line::Delete(line) => ('-', line.as_ref(), style::DELETE),
+            Line::Insert(line) => ('+', line.as_ref(), style::INSERT),
         };
 
-        if let (true, Some(style)) = (self.f.with_color, style) {
+        if self.f.with_color {
             write!(w, "{style}")?;
         }
 
         if self.f.suppress_blank_empty && sign == ' ' && line == b"\n" {
             w.write_all(line)?;
         } else {
-            write!(w, "{}", sign)?;
+            write!(w, "{sign}")?;
             w.write_all(line)?;
         }
 
-        if let (true, Some(style)) = (self.f.with_color, style) {
+        if self.f.with_color {
             write!(w, "{style:#}")?;
         }
 
         if !line.ends_with(b"\n") {
             writeln!(w)?;
             if self.f.with_missing_newline_message {
-                writeln!(w, "{}", NO_NEWLINE_AT_EOF)?;
+                writeln!(w, "{NO_NEWLINE_AT_EOF}")?;
             }
         }
 
@@ -261,29 +261,29 @@ impl<T: AsRef<[u8]> + ?Sized> LineDisplay<'_, T> {
 impl Display for LineDisplay<'_, str> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         let (sign, line, style) = match self.line {
-            Line::Context(line) => (' ', line, None),
-            Line::Delete(line) => ('-', line, Some(style::DELETE)),
-            Line::Insert(line) => ('+', line, Some(style::INSERT)),
+            Line::Context(line) => (' ', line, style::NOP),
+            Line::Delete(line) => ('-', line, style::DELETE),
+            Line::Insert(line) => ('+', line, style::INSERT),
         };
 
-        if let (true, Some(style)) = (self.f.with_color, style) {
+        if self.f.with_color {
             write!(f, "{style}")?;
         }
 
         if self.f.suppress_blank_empty && sign == ' ' && *line == "\n" {
-            write!(f, "{}", line)?;
+            write!(f, "{line}")?;
         } else {
-            write!(f, "{}{}", sign, line)?;
+            write!(f, "{sign}{line}")?;
         }
 
-        if let (true, Some(style)) = (self.f.with_color, style) {
+        if self.f.with_color {
             write!(f, "{style:#}")?;
         }
 
         if !line.ends_with('\n') {
             writeln!(f)?;
             if self.f.with_missing_newline_message {
-                writeln!(f, "{}", NO_NEWLINE_AT_EOF)?;
+                writeln!(f, "{NO_NEWLINE_AT_EOF}")?;
             }
         }
 

--- a/src/patch/format.rs
+++ b/src/patch/format.rs
@@ -3,12 +3,14 @@ use std::{
     io,
 };
 
+#[cfg(feature = "color")]
 use super::style;
 use super::{Hunk, Line, Patch, NO_NEWLINE_AT_EOF};
 
 /// Struct used to adjust the formatting of a `Patch`
 #[derive(Debug)]
 pub struct PatchFormatter {
+    #[cfg(feature = "color")]
     with_color: bool,
     with_missing_newline_message: bool,
     suppress_blank_empty: bool,
@@ -18,6 +20,7 @@ impl PatchFormatter {
     /// Construct a new formatter
     pub fn new() -> Self {
         Self {
+            #[cfg(feature = "color")]
             with_color: false,
             with_missing_newline_message: true,
 
@@ -28,6 +31,7 @@ impl PatchFormatter {
     }
 
     /// Enable formatting a patch with color
+    #[cfg(feature = "color")]
     pub fn with_color(mut self) -> Self {
         self.with_color = true;
         self
@@ -96,6 +100,17 @@ impl PatchFormatter {
     ) -> io::Result<()> {
         LineDisplay { f: self, line }.write_into(w)
     }
+
+    #[cfg(feature = "color")]
+    fn use_color(&self) -> bool {
+        self.with_color
+    }
+
+    #[cfg(not(feature = "color"))]
+    #[allow(dead_code)]
+    fn use_color(&self) -> bool {
+        false
+    }
 }
 
 impl Default for PatchFormatter {
@@ -112,9 +127,9 @@ struct PatchDisplay<'a, T: ToOwned + ?Sized> {
 impl<T: ToOwned + AsRef<[u8]> + ?Sized> PatchDisplay<'_, T> {
     fn write_into<W: io::Write>(&self, mut w: W) -> io::Result<()> {
         if self.patch.original.is_some() || self.patch.modified.is_some() {
-            let style = style::PATCH_HEADER;
-            if self.f.with_color {
-                write!(w, "{style}")?;
+            #[cfg(feature = "color")]
+            if self.f.use_color() {
+                write!(w, "{}", style::PATCH_HEADER)?;
             }
             if let Some(original) = &self.patch.original {
                 write!(w, "--- ")?;
@@ -126,8 +141,9 @@ impl<T: ToOwned + AsRef<[u8]> + ?Sized> PatchDisplay<'_, T> {
                 modified.write_into(&mut w)?;
                 writeln!(w)?;
             }
-            if self.f.with_color {
-                write!(w, "{style:#}")?;
+            #[cfg(feature = "color")]
+            if self.f.use_color() {
+                write!(w, "{:#}", style::PATCH_HEADER)?;
             }
         }
 
@@ -142,9 +158,9 @@ impl<T: ToOwned + AsRef<[u8]> + ?Sized> PatchDisplay<'_, T> {
 impl Display for PatchDisplay<'_, str> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         if self.patch.original.is_some() || self.patch.modified.is_some() {
-            let style = style::PATCH_HEADER;
-            if self.f.with_color {
-                write!(f, "{style}")?;
+            #[cfg(feature = "color")]
+            if self.f.use_color() {
+                write!(f, "{}", style::PATCH_HEADER)?;
             }
             if let Some(original) = &self.patch.original {
                 writeln!(f, "--- {original}")?;
@@ -152,8 +168,9 @@ impl Display for PatchDisplay<'_, str> {
             if let Some(modified) = &self.patch.modified {
                 writeln!(f, "+++ {modified}")?;
             }
-            if self.f.with_color {
-                write!(f, "{style:#}")?;
+            #[cfg(feature = "color")]
+            if self.f.use_color() {
+                write!(f, "{:#}", style::PATCH_HEADER)?;
             }
         }
 
@@ -172,13 +189,14 @@ struct HunkDisplay<'a, T: ?Sized> {
 
 impl<T: AsRef<[u8]> + ?Sized> HunkDisplay<'_, T> {
     fn write_into<W: io::Write>(&self, mut w: W) -> io::Result<()> {
-        let style = style::HUNK_HEADER;
-        if self.f.with_color {
-            write!(w, "{style}")?;
+        #[cfg(feature = "color")]
+        if self.f.use_color() {
+            write!(w, "{}", style::HUNK_HEADER)?;
         }
         write!(w, "@@ -{} +{} @@", self.hunk.old_range, self.hunk.new_range)?;
-        if self.f.with_color {
-            write!(w, "{style:#}")?;
+        #[cfg(feature = "color")]
+        if self.f.use_color() {
+            write!(w, "{:#}", style::HUNK_HEADER)?;
         }
 
         if let Some(ctx) = self.hunk.function_context {
@@ -197,13 +215,14 @@ impl<T: AsRef<[u8]> + ?Sized> HunkDisplay<'_, T> {
 
 impl Display for HunkDisplay<'_, str> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        let style = style::HUNK_HEADER;
-        if self.f.with_color {
-            write!(f, "{style}")?;
+        #[cfg(feature = "color")]
+        if self.f.use_color() {
+            write!(f, "{}", style::HUNK_HEADER)?;
         }
         write!(f, "@@ -{} +{} @@", self.hunk.old_range, self.hunk.new_range)?;
-        if self.f.with_color {
-            write!(f, "{style:#}")?;
+        #[cfg(feature = "color")]
+        if self.f.use_color() {
+            write!(f, "{:#}", style::HUNK_HEADER)?;
         }
 
         if let Some(ctx) = self.hunk.function_context {
@@ -226,13 +245,21 @@ struct LineDisplay<'a, T: ?Sized> {
 
 impl<T: AsRef<[u8]> + ?Sized> LineDisplay<'_, T> {
     fn write_into<W: io::Write>(&self, mut w: W) -> io::Result<()> {
+        #[cfg(feature = "color")]
         let (sign, line, style) = match self.line {
             Line::Context(line) => (' ', line.as_ref(), style::NOP),
             Line::Delete(line) => ('-', line.as_ref(), style::DELETE),
             Line::Insert(line) => ('+', line.as_ref(), style::INSERT),
         };
+        #[cfg(not(feature = "color"))]
+        let (sign, line) = match self.line {
+            Line::Context(line) => (' ', line.as_ref()),
+            Line::Delete(line) => ('-', line.as_ref()),
+            Line::Insert(line) => ('+', line.as_ref()),
+        };
 
-        if self.f.with_color {
+        #[cfg(feature = "color")]
+        if self.f.use_color() {
             write!(w, "{style}")?;
         }
 
@@ -243,7 +270,8 @@ impl<T: AsRef<[u8]> + ?Sized> LineDisplay<'_, T> {
             w.write_all(line)?;
         }
 
-        if self.f.with_color {
+        #[cfg(feature = "color")]
+        if self.f.use_color() {
             write!(w, "{style:#}")?;
         }
 
@@ -260,13 +288,21 @@ impl<T: AsRef<[u8]> + ?Sized> LineDisplay<'_, T> {
 
 impl Display for LineDisplay<'_, str> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        #[cfg(feature = "color")]
         let (sign, line, style) = match self.line {
             Line::Context(line) => (' ', line, style::NOP),
             Line::Delete(line) => ('-', line, style::DELETE),
             Line::Insert(line) => ('+', line, style::INSERT),
         };
+        #[cfg(not(feature = "color"))]
+        let (sign, line) = match self.line {
+            Line::Context(line) => (' ', line),
+            Line::Delete(line) => ('-', line),
+            Line::Insert(line) => ('+', line),
+        };
 
-        if self.f.with_color {
+        #[cfg(feature = "color")]
+        if self.f.use_color() {
             write!(f, "{style}")?;
         }
 
@@ -276,7 +312,8 @@ impl Display for LineDisplay<'_, str> {
             write!(f, "{sign}{line}")?;
         }
 
-        if self.f.with_color {
+        #[cfg(feature = "color")]
+        if self.f.use_color() {
             write!(f, "{style:#}")?;
         }
 

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -1,5 +1,6 @@
 mod format;
 mod parse;
+#[cfg(feature = "color")]
 mod style;
 
 pub use format::PatchFormatter;

--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -1,5 +1,6 @@
 mod format;
 mod parse;
+mod style;
 
 pub use format::PatchFormatter;
 pub use parse::ParsePatchError;

--- a/src/patch/style.rs
+++ b/src/patch/style.rs
@@ -1,0 +1,10 @@
+use anstyle::AnsiColor;
+use anstyle::Style;
+
+pub const CONTEXT: Style = Style::new();
+pub const FUNCTION_CONTEXT: Style = Style::new();
+
+pub const DELETE: Style = AnsiColor::Red.on_default();
+pub const HUNK_HEADER: Style = AnsiColor::Cyan.on_default();
+pub const INSERT: Style = AnsiColor::Green.on_default();
+pub const PATCH_HEADER: Style = Style::new().bold();

--- a/src/patch/style.rs
+++ b/src/patch/style.rs
@@ -1,6 +1,7 @@
 use anstyle::AnsiColor;
 use anstyle::Style;
 
+pub const NOP: Style = Style::new();
 pub const DELETE: Style = AnsiColor::Red.on_default();
 pub const HUNK_HEADER: Style = AnsiColor::Cyan.on_default();
 pub const INSERT: Style = AnsiColor::Green.on_default();

--- a/src/patch/style.rs
+++ b/src/patch/style.rs
@@ -1,9 +1,6 @@
 use anstyle::AnsiColor;
 use anstyle::Style;
 
-pub const CONTEXT: Style = Style::new();
-pub const FUNCTION_CONTEXT: Style = Style::new();
-
 pub const DELETE: Style = AnsiColor::Red.on_default();
 pub const HUNK_HEADER: Style = AnsiColor::Cyan.on_default();
 pub const INSERT: Style = AnsiColor::Green.on_default();

--- a/src/patchset/parse.rs
+++ b/src/patchset/parse.rs
@@ -80,30 +80,30 @@ pub fn split_patches(content: &str, mode: ParseMode) -> Vec<&str> {
 fn is_patch_boundary(prev: Option<&str>, line: &str, next: Option<&str>, _mode: ParseMode) -> bool {
     if line.starts_with(ORIGINAL_PREFIX) {
         // Make sure it isn't part of a (`+++` / `--- `) pair
-        if prev.map_or(false, |p| p.starts_with(MODIFIED_PREFIX)) {
+        if prev.is_some_and(|p| p.starts_with(MODIFIED_PREFIX)) {
             return false;
         }
         // `--- ` followed by `+++ `
-        if next.map_or(false, |n| n.starts_with(MODIFIED_PREFIX)) {
+        if next.is_some_and(|n| n.starts_with(MODIFIED_PREFIX)) {
             return true;
         }
         // `--- ` followed by `@@ `
-        if next.map_or(false, |n| n.starts_with(HUNK_PREFIX)) {
+        if next.is_some_and(|n| n.starts_with(HUNK_PREFIX)) {
             return true;
         }
     }
 
     if line.starts_with(MODIFIED_PREFIX) {
         // Make sure it isn't part of a (`---` / `+++`) pair
-        if prev.map_or(false, |p| p.starts_with(ORIGINAL_PREFIX)) {
+        if prev.is_some_and(|p| p.starts_with(ORIGINAL_PREFIX)) {
             return false;
         }
         // `+++ ` followed by `--- `
-        if next.map_or(false, |n| n.starts_with(ORIGINAL_PREFIX)) {
+        if next.is_some_and(|n| n.starts_with(ORIGINAL_PREFIX)) {
             return true;
         }
         // `+++ ` followed by `@@ `
-        if next.map_or(false, |n| n.starts_with(HUNK_PREFIX)) {
+        if next.is_some_and(|n| n.starts_with(HUNK_PREFIX)) {
             return true;
         }
     }


### PR DESCRIPTION
This also

* Bump MSRV from 1.62.1 to 1.70
* Make style optional by introducing a new `color` Cargo feature, and put `PatchFormatter::with_color` behind that.