### PR TITLE
test: add configurable git history replay test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
+      - git-format-patch
   pull_request:
 
 env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,28 @@ jobs:
       - run: cargo fmt -- --check
       - run: cargo clippy --all-targets
       - run: cargo doc --no-deps
+
+  history-replay:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: diffy
+            repo: .
+            commits: 0
+          - name: cargo
+            repo: target/test-repo
+            clone: https://github.com/rust-lang/cargo --depth 201
+            commits: 200
+    name: history-replay (${{ matrix.name }})
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: ${{ matrix.clone && 1 || 0 }}
+      - if: matrix.clone
+        run: git clone ${{ matrix.clone }} ${{ matrix.repo }}
+      - run: rustup toolchain install stable --profile minimal
+      - run: cargo test --release --test git_history_replay -- --nocapture
+        env:
+          DIFFY_TEST_REPO: ${{ matrix.repo }}
+          DIFFY_TEST_COMMITS: ${{ matrix.commits }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,10 @@ jobs:
             repo: target/test-repo
             clone: https://github.com/rust-lang/cargo --depth 201
             commits: 200
+          - name: rust
+            repo: target/test-repo
+            clone: https://github.com/rust-lang/rust --depth 31
+            commits: 30
     name: history-replay (${{ matrix.name }})
     steps:
       - uses: actions/checkout@v6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,7 @@ anstyle = { version = "1.0.13", optional = true }
 [[example]]
 name = "patch_formatter"
 required-features = ["color"]
+
+[[test]]
+name = "git_history_replay"
+test = false

--- a/tests/git_history_replay.rs
+++ b/tests/git_history_replay.rs
@@ -20,10 +20,22 @@
 use std::env;
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::mpsc;
+use std::thread;
 
 use diffy::patchset::FileOperation;
 use diffy::patchset::ParseMode;
 use diffy::patchset::PatchSet;
+
+/// Result of processing a single commit pair.
+struct CommitResult {
+    idx: usize,
+    parent_short: String,
+    child_short: String,
+    files: Vec<String>,
+    applied: usize,
+    skipped: usize,
+}
 
 /// Get the repository path from environment variable.
 ///
@@ -106,6 +118,109 @@ fn commit_history(repo: &PathBuf, max: usize) -> Vec<String> {
     commits
 }
 
+/// Process a single commit pair and return the result.
+fn process_commit(repo: &PathBuf, idx: usize, parent: &str, child: &str) -> CommitResult {
+    let parent_short = parent[..8].to_string();
+    let child_short = child[..8].to_string();
+    let mut files = Vec::new();
+    let mut applied = 0;
+    let mut skipped = 0;
+
+    let diff_output = git(repo, &["diff", parent, child]);
+
+    if diff_output.is_empty() {
+        // No changes (could be metadata-only commit)
+        return CommitResult {
+            idx,
+            parent_short,
+            child_short,
+            files,
+            applied,
+            skipped,
+        };
+    }
+
+    let patchset = match PatchSet::parse(&diff_output, ParseMode::UniDiff) {
+        Ok(ps) => ps,
+        Err(e) => {
+            panic!(
+                "Failed to parse patch for {parent_short}..{child_short}: {e}\n\n\
+                Diff:\n{diff_output}"
+            );
+        }
+    };
+
+    for file_patch in patchset.iter() {
+        let operation = file_patch.operation().strip_prefix(1);
+
+        let (base_content, expected_content, desc) = match &operation {
+            FileOperation::Create(path) => {
+                let Some(expected) = file_at_commit(repo, child, path) else {
+                    skipped += 1;
+                    continue;
+                };
+                (String::new(), expected, format!("create {path}"))
+            }
+            FileOperation::Delete(path) => {
+                let Some(base) = file_at_commit(repo, parent, path) else {
+                    skipped += 1;
+                    continue;
+                };
+                (base, String::new(), format!("delete {path}"))
+            }
+            FileOperation::Modify { from, to } => {
+                let Some(base) = file_at_commit(repo, parent, from) else {
+                    skipped += 1;
+                    continue;
+                };
+                let Some(expected) = file_at_commit(repo, child, to) else {
+                    skipped += 1;
+                    continue;
+                };
+                let desc = if from == to {
+                    format!("modify {from}")
+                } else {
+                    format!("rename {from} -> {to}")
+                };
+                (base, expected, desc)
+            }
+        };
+
+        let patch = file_patch.patch();
+        let result = match diffy::apply(&base_content, patch) {
+            Ok(r) => r,
+            Err(e) => {
+                panic!(
+                    "Failed to apply patch at {parent_short}..{child_short} for {desc}: {e}\n\n\
+                    Patch:\n{patch}\n\n\
+                    Base content:\n{base_content}"
+                );
+            }
+        };
+
+        if result != expected_content {
+            panic!(
+                "Content mismatch at {parent_short}..{child_short} for {desc}\n\n\
+                --- Expected ---\n{expected_content}\n\n\
+                --- Got ---\n{result}\n\n\
+                --- Patch ---\n{patch}"
+            );
+        }
+
+        applied += 1;
+        files.push(desc);
+    }
+
+    CommitResult {
+        idx,
+        parent_short,
+        child_short,
+        files,
+        applied,
+        skipped,
+    }
+}
+
 #[test]
 fn test_git_history_replay() {
     let repo = repo_path();
@@ -118,109 +233,53 @@ fn test_git_history_replay() {
     }
 
     let total_diffs = commits.len() - 1;
-    let mut total_patches = 0;
-    let mut applied_patches = 0;
-    let mut skipped_binary = 0;
+    let repo_name = repo
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| ".".to_string());
 
-    for (i, window) in commits.windows(2).enumerate() {
-        let idx = i + 1;
-        let parent = &window[0];
-        let child = &window[1];
-        let parent_short = &parent[..8];
-        let child_short = &child[..8];
+    let (tx, rx) = mpsc::channel::<CommitResult>();
+    let repo = &repo;
 
-        let repo_name = repo
-            .file_name()
-            .map(|n| n.to_string_lossy().into_owned())
-            .unwrap_or_else(|| ".".to_string());
-        eprintln!("[{idx}/{total_diffs}] ({repo_name}) Processing {parent_short}..{child_short}",);
+    thread::scope(|s| {
+        // Spawn worker threads
+        for (i, window) in commits.windows(2).enumerate() {
+            let tx = tx.clone();
+            let parent = &window[0];
+            let child = &window[1];
 
-        let diff_output = git(&repo, &["diff", parent, child]);
-
-        if diff_output.is_empty() {
-            // No changes (could be metadata-only commit)
-            continue;
+            s.spawn(move || {
+                let result = process_commit(repo, i, parent, child);
+                tx.send(result).expect("failed to send result");
+            });
         }
 
-        let patchset = match PatchSet::parse(&diff_output, ParseMode::UniDiff) {
-            Ok(ps) => ps,
-            Err(e) => {
-                panic!(
-                    "Failed to parse patch for {parent_short}..{child_short}: {e}\n\n\
-                    Diff:\n{diff_output}"
-                );
+        drop(tx);
+
+        let mut results: Vec<_> = rx.iter().collect();
+        results.sort_by_key(|r| r.idx);
+
+        let mut total_applied = 0;
+        let mut total_skipped = 0;
+
+        for result in results {
+            let idx = result.idx + 1;
+            eprintln!(
+                "[{idx}/{total_diffs}] ({repo_name}) Processing {}..{}",
+                result.parent_short, result.child_short
+            );
+            for desc in &result.files {
+                eprintln!("  ✓ {desc}");
             }
-        };
-
-        for file_patch in patchset.iter() {
-            total_patches += 1;
-
-            let operation = file_patch.operation().strip_prefix(1);
-
-            let (base_content, expected_content, desc) = match &operation {
-                FileOperation::Create(path) => {
-                    let Some(expected) = file_at_commit(&repo, child, path) else {
-                        skipped_binary += 1;
-                        continue;
-                    };
-                    (String::new(), expected, format!("create {path}"))
-                }
-                FileOperation::Delete(path) => {
-                    let Some(base) = file_at_commit(&repo, parent, path) else {
-                        skipped_binary += 1;
-                        continue;
-                    };
-                    (base, String::new(), format!("delete {path}"))
-                }
-                FileOperation::Modify { from, to } => {
-                    let Some(base) = file_at_commit(&repo, parent, from) else {
-                        skipped_binary += 1;
-                        continue;
-                    };
-                    let Some(expected) = file_at_commit(&repo, child, to) else {
-                        skipped_binary += 1;
-                        continue;
-                    };
-                    let desc = if from == to {
-                        format!("modify {from}")
-                    } else {
-                        format!("rename {from} -> {to}")
-                    };
-                    (base, expected, desc)
-                }
-            };
-
-            let patch = file_patch.patch();
-            let result = match diffy::apply(&base_content, patch) {
-                Ok(r) => r,
-                Err(e) => {
-                    panic!(
-                        "Failed to apply patch at {parent_short}..{child_short} for {desc}: {e}\n\n\
-                        Patch:\n{patch}\n\n\
-                        Base content:\n{base_content}"
-                    );
-                }
-            };
-
-            if result != expected_content {
-                panic!(
-                    "Content mismatch at {parent_short}..{child_short} for {desc}\n\n\
-                    --- Expected ---\n{expected_content}\n\n\
-                    --- Got ---\n{result}\n\n\
-                    --- Patch ---\n{patch}"
-                );
-            }
-
-            applied_patches += 1;
-            eprintln!("  ✓ {desc}");
+            total_applied += result.applied;
+            total_skipped += result.skipped;
         }
-    }
 
-    eprintln!("History replay completed: {applied_patches} patches applied, {skipped_binary} skipped (binary)");
+        eprintln!(
+            "History replay completed: {total_applied} patches applied, {total_skipped} skipped (binary)"
+        );
 
-    // Sanity check: we should have applied at least some patches
-    assert!(
-        applied_patches > 0,
-        "No patches were applied, total_patches={total_patches}"
-    );
+        // Sanity check: we should have applied at least some patches
+        assert!(total_applied > 0, "No patches were applied");
+    });
 }

--- a/tests/git_history_replay.rs
+++ b/tests/git_history_replay.rs
@@ -1,0 +1,226 @@
+//! Validate PatchSet parsing and application by replaying a git repository's history.
+//!
+//! ## Usage
+//!
+//! ```console
+//! $ cargo test --test git_history_replay -- --nocapture
+//! ```
+//!
+//! ## Environment Variables
+//!
+//! * `DIFFY_TEST_REPO`: Path to the git repository to test against.
+//!   Defaults to the package directory (`CARGO_MANIFEST_DIR`).
+//! * `DIFFY_TEST_COMMITS`: Maximum number of commits to verify.
+//!   Defaults to 200. Use `0` to verify entire history.
+//!
+//! ## Requirements
+//!
+//! * Git must be installed and available in the system's PATH.
+
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
+
+use diffy::patchset::FileOperation;
+use diffy::patchset::ParseMode;
+use diffy::patchset::PatchSet;
+
+/// Get the repository path from environment variable.
+///
+/// Defaults to package directory if `DIFFY_TEST_REPO` is not set.
+fn repo_path() -> PathBuf {
+    env::var("DIFFY_TEST_REPO")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(env!("CARGO_MANIFEST_DIR")))
+}
+
+fn max_commits() -> usize {
+    let Ok(val) = env::var("DIFFY_TEST_COMMITS") else {
+        return 200;
+    };
+    let val = val.trim();
+    if val == "0" {
+        usize::MAX
+    } else {
+        val.parse()
+            .unwrap_or_else(|e| panic!("invalid DIFFY_TEST_COMMITS='{val}': {e}"))
+    }
+}
+
+fn git(repo: &PathBuf, args: &[&str]) -> String {
+    let mut cmd = Command::new("git");
+    // Run in a clean context without user/system config for reproducibility
+    cmd.env("GIT_CONFIG_NOSYSTEM", "1");
+    cmd.env("GIT_CONFIG_GLOBAL", "/dev/null");
+    cmd.arg("-C").arg(repo);
+    cmd.args(args);
+
+    let output = cmd.output().expect("failed to execute git");
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        panic!("git {args:?} failed: {stderr}");
+    }
+
+    String::from_utf8(output.stdout).expect("git output is not valid UTF-8")
+}
+
+/// Get file content at a specific commit.
+///
+/// Returns `None` if the file is binary (not valid UTF-8).
+fn file_at_commit(repo: &PathBuf, commit: &str, path: &str) -> Option<String> {
+    let mut cmd = Command::new("git");
+    cmd.env("GIT_CONFIG_NOSYSTEM", "1");
+    cmd.env("GIT_CONFIG_GLOBAL", "/dev/null");
+    cmd.arg("-C").arg(repo);
+    cmd.args(["show", &format!("{commit}:{path}")]);
+
+    let output = cmd.output().expect("failed to execute git show");
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        panic!("file {path} doesn't exist at {commit}: {stderr}");
+    }
+
+    // None for binary files (non-UTF8)
+    String::from_utf8(output.stdout).ok()
+}
+
+/// Get the list of commits from oldest to newest.
+fn commit_history(repo: &PathBuf, max: usize) -> Vec<String> {
+    // Note: `git rev-list -n N HEAD` returns newest N commits (newest first).
+    // `git rev-list --reverse -n N HEAD` returns OLDEST N commits.
+    // We want newest N in chronological order, so: fetch newest, then reverse.
+    let output = if max == usize::MAX {
+        git(repo, &["rev-list", "--reverse", "HEAD"])
+    } else {
+        // fetches only the most recent `max + 1` commits
+        // to have `max` commit pairs for diffing.
+        let n = (max + 1).to_string();
+        git(repo, &["rev-list", "-n", &n, "HEAD"])
+    };
+    let mut commits: Vec<_> = output.lines().map(String::from).collect();
+    if max != usize::MAX {
+        commits.reverse();
+    }
+    commits
+}
+
+#[test]
+fn test_git_history_replay() {
+    let repo = repo_path();
+    let max = max_commits();
+    let commits = commit_history(&repo, max);
+
+    if commits.len() < 2 {
+        eprintln!("Not enough commits to test, skipping");
+        return;
+    }
+
+    let total_diffs = commits.len() - 1;
+    let mut total_patches = 0;
+    let mut applied_patches = 0;
+    let mut skipped_binary = 0;
+
+    for (i, window) in commits.windows(2).enumerate() {
+        let idx = i + 1;
+        let parent = &window[0];
+        let child = &window[1];
+        let parent_short = &parent[..8];
+        let child_short = &child[..8];
+
+        let repo_name = repo
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| ".".to_string());
+        eprintln!("[{idx}/{total_diffs}] ({repo_name}) Processing {parent_short}..{child_short}",);
+
+        let diff_output = git(&repo, &["diff", parent, child]);
+
+        if diff_output.is_empty() {
+            // No changes (could be metadata-only commit)
+            continue;
+        }
+
+        let patchset = match PatchSet::parse(&diff_output, ParseMode::UniDiff) {
+            Ok(ps) => ps,
+            Err(e) => {
+                panic!(
+                    "Failed to parse patch for {parent_short}..{child_short}: {e}\n\n\
+                    Diff:\n{diff_output}"
+                );
+            }
+        };
+
+        for file_patch in patchset.iter() {
+            total_patches += 1;
+
+            let operation = file_patch.operation().strip_prefix(1);
+
+            let (base_content, expected_content, desc) = match &operation {
+                FileOperation::Create(path) => {
+                    let Some(expected) = file_at_commit(&repo, child, path) else {
+                        skipped_binary += 1;
+                        continue;
+                    };
+                    (String::new(), expected, format!("create {path}"))
+                }
+                FileOperation::Delete(path) => {
+                    let Some(base) = file_at_commit(&repo, parent, path) else {
+                        skipped_binary += 1;
+                        continue;
+                    };
+                    (base, String::new(), format!("delete {path}"))
+                }
+                FileOperation::Modify { from, to } => {
+                    let Some(base) = file_at_commit(&repo, parent, from) else {
+                        skipped_binary += 1;
+                        continue;
+                    };
+                    let Some(expected) = file_at_commit(&repo, child, to) else {
+                        skipped_binary += 1;
+                        continue;
+                    };
+                    let desc = if from == to {
+                        format!("modify {from}")
+                    } else {
+                        format!("rename {from} -> {to}")
+                    };
+                    (base, expected, desc)
+                }
+            };
+
+            let patch = file_patch.patch();
+            let result = match diffy::apply(&base_content, patch) {
+                Ok(r) => r,
+                Err(e) => {
+                    panic!(
+                        "Failed to apply patch at {parent_short}..{child_short} for {desc}: {e}\n\n\
+                        Patch:\n{patch}\n\n\
+                        Base content:\n{base_content}"
+                    );
+                }
+            };
+
+            if result != expected_content {
+                panic!(
+                    "Content mismatch at {parent_short}..{child_short} for {desc}\n\n\
+                    --- Expected ---\n{expected_content}\n\n\
+                    --- Got ---\n{result}\n\n\
+                    --- Patch ---\n{patch}"
+                );
+            }
+
+            applied_patches += 1;
+            eprintln!("  ✓ {desc}");
+        }
+    }
+
+    eprintln!("History replay completed: {applied_patches} patches applied, {skipped_binary} skipped (binary)");
+
+    // Sanity check: we should have applied at least some patches
+    assert!(
+        applied_patches > 0,
+        "No patches were applied, total_patches={total_patches}"
+    );
+}

--- a/tests/git_history_replay.rs
+++ b/tests/git_history_replay.rs
@@ -61,7 +61,6 @@ fn max_commits() -> usize {
 
 fn git(repo: &PathBuf, args: &[&str]) -> String {
     let mut cmd = Command::new("git");
-    // Run in a clean context without user/system config for reproducibility
     cmd.env("GIT_CONFIG_NOSYSTEM", "1");
     cmd.env("GIT_CONFIG_GLOBAL", "/dev/null");
     cmd.arg("-C").arg(repo);
@@ -77,10 +76,34 @@ fn git(repo: &PathBuf, args: &[&str]) -> String {
     String::from_utf8(output.stdout).expect("git output is not valid UTF-8")
 }
 
+/// Check if a path is a submodule at a specific commit.
+fn is_submodule(repo: &PathBuf, commit: &str, path: &str) -> bool {
+    let mut cmd = Command::new("git");
+    cmd.env("GIT_CONFIG_NOSYSTEM", "1");
+    cmd.env("GIT_CONFIG_GLOBAL", "/dev/null");
+    cmd.arg("-C").arg(repo);
+    cmd.args(["ls-tree", "--format=%(objectmode)", commit, "--", path]);
+
+    let output = cmd.output().expect("failed to execute git ls-tree");
+
+    if !output.status.success() {
+        return false;
+    }
+
+    String::from_utf8_lossy(&output.stdout).trim() == "160000"
+}
+
 /// Get file content at a specific commit.
 ///
-/// Returns `None` if the file is binary (not valid UTF-8).
+/// Returns `None` if:
+///
+/// * The path is a submodule
+/// * The file is binary (not valid UTF-8)
 fn file_at_commit(repo: &PathBuf, commit: &str, path: &str) -> Option<String> {
+    if is_submodule(repo, commit, path) {
+        return None;
+    }
+
     let mut cmd = Command::new("git");
     cmd.env("GIT_CONFIG_NOSYSTEM", "1");
     cmd.env("GIT_CONFIG_GLOBAL", "/dev/null");
@@ -100,8 +123,6 @@ fn file_at_commit(repo: &PathBuf, commit: &str, path: &str) -> Option<String> {
 
 /// Get the list of commits from oldest to newest.
 fn commit_history(repo: &PathBuf, max: usize) -> Vec<String> {
-    // Note: `git rev-list -n N HEAD` returns newest N commits (newest first).
-    // `git rev-list --reverse -n N HEAD` returns OLDEST N commits.
     // We want newest N in chronological order, so: fetch newest, then reverse.
     let output = if max == usize::MAX {
         git(repo, &["rev-list", "--reverse", "HEAD"])
@@ -118,7 +139,6 @@ fn commit_history(repo: &PathBuf, max: usize) -> Vec<String> {
     commits
 }
 
-/// Process a single commit pair and return the result.
 fn process_commit(repo: &PathBuf, idx: usize, parent: &str, child: &str) -> CommitResult {
     let parent_short = parent[..8].to_string();
     let child_short = child[..8].to_string();
@@ -242,7 +262,6 @@ fn test_git_history_replay() {
     let repo = &repo;
 
     thread::scope(|s| {
-        // Spawn worker threads
         for (i, window) in commits.windows(2).enumerate() {
             let tx = tx.clone();
             let parent = &window[0];
@@ -276,7 +295,7 @@ fn test_git_history_replay() {
         }
 
         eprintln!(
-            "History replay completed: {total_applied} patches applied, {total_skipped} skipped (binary)"
+            "History replay completed: {total_applied} patches applied, {total_skipped} skipped"
         );
 
         // Sanity check: we should have applied at least some patches


### PR DESCRIPTION
It is disabled by default.

We run it in a CI job for full history verification

Currently test against

* self
* rust-lang/cargo
* rust-lang/rust