### PR TITLE
feat(patchset): add basic `ParseMode::GitDiff`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,15 +42,41 @@ jobs:
           - name: diffy
             repo: .
             commits: 0
+            parse_mode: unidiff
+          - name: diffy
+            repo: .
+            commits: 0
+            parse_mode: gitdiff
           - name: cargo
             repo: target/test-repo
             clone: https://github.com/rust-lang/cargo --depth 201
             commits: 200
+            parse_mode: unidiff
+          - name: cargo
+            repo: target/test-repo
+            clone: https://github.com/rust-lang/cargo --depth 201
+            commits: 200
+            parse_mode: gitdiff
           - name: rust
             repo: target/test-repo
             clone: https://github.com/rust-lang/rust --depth 31
             commits: 30
-    name: history-replay (${{ matrix.name }})
+            parse_mode: unidiff
+          - name: rust
+            repo: target/test-repo
+            clone: https://github.com/rust-lang/rust --depth 31
+            commits: 30
+            parse_mode: gitdiff
+    name: history-replay (${{ matrix.name }}, ${{ matrix.parse_mode }})
+    # GitDiff mode doesn't yet handle no-hunk patches, for example pure renames:
+    #
+    #     diff --git a/src/patch.rs b/src/patch/mod.rs
+    #     similarity index 100%
+    #     rename from src/patch.rs
+    #     rename to src/patch/mod.rs
+    #
+    # Track progress without blocking CI.
+    continue-on-error: ${{ matrix.parse_mode == 'gitdiff' }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -62,3 +88,4 @@ jobs:
         env:
           DIFFY_TEST_REPO: ${{ matrix.repo }}
           DIFFY_TEST_COMMITS: ${{ matrix.commits }}
+          DIFFY_TEST_PARSE_MODE: ${{ matrix.parse_mode }}

--- a/src/patchset/mod.rs
+++ b/src/patchset/mod.rs
@@ -25,6 +25,11 @@ pub enum ParseMode {
     ///
     /// [unified diff]: https://www.gnu.org/software/diffutils/manual/html_node/Unified-Format.html
     UniDiff,
+
+    /// [Git extended diff format][git-diff-format].
+    ///
+    /// [git-diff-format]: https://git-scm.com/docs/diff-format
+    GitDiff,
 }
 
 /// A collection of patches for multiple files.

--- a/src/patchset/parse.rs
+++ b/src/patchset/parse.rs
@@ -12,16 +12,29 @@ const HUNK_PREFIX: &str = "@@ ";
 /// Path used to indicate file creation or deletion.
 const DEV_NULL: &str = "/dev/null";
 
+/// Prefix for git diff header (e.g., `diff --git a/file b/file`).
+const GIT_DIFF_PREFIX: &str = "diff --git ";
+
+/// Separator between commit message and patch in git format-patch output.
+const EMAIL_PREAMBLE_SEPARATOR: &str = "\n---\n";
+
 /// Parse a multi-file patch.
 ///
-/// This would strips:
+/// This strips:
 ///
-/// * headers (including email-style headers and commit messages)
+/// * email preamble (headers and commit message before `---` separator)
 /// * trailing email signature
 pub fn parse(input: &str, mode: ParseMode) -> Result<PatchSet<'_, str>, ParsePatchError> {
     // Email signatures would be parsed as a delete line and corrupt the hunk.
     // Must strip before parsing.
     let input = strip_email_signature(input);
+
+    // In GitDiff mode, strip email preamble to avoid false `diff --git` matches
+    // in commit messages.
+    let input = match mode {
+        ParseMode::GitDiff => strip_email_preamble(input),
+        ParseMode::UniDiff => input,
+    };
 
     let patch_strs = split_patches(input, mode);
 
@@ -72,14 +85,29 @@ pub fn split_patches(content: &str, mode: ParseMode) -> Vec<&str> {
 }
 
 /// Checks if the current line is a patch boundary.
+fn is_patch_boundary(prev: Option<&str>, line: &str, next: Option<&str>, mode: ParseMode) -> bool {
+    match mode {
+        ParseMode::GitDiff => is_gitdiff_boundary(line),
+        ParseMode::UniDiff => is_unidiff_boundary(prev, line, next),
+    }
+}
+
+/// Checks if the current line is a patch boundary in GitDiff mode.
+///
+/// Only `diff --git ` is recognized as a boundary.
+fn is_gitdiff_boundary(line: &str) -> bool {
+    line.starts_with(GIT_DIFF_PREFIX)
+}
+
+/// Checks if the current line is a patch boundary in UniDiff mode.
 ///
 /// A patch boundary is one of:
 ///
-/// - `--- ` followed by `+++ ` on the next line
-/// - `+++ ` followed by `--- ` on the next line
-/// - `--- ` followed by `@@ ` on the next line (missing `+++`)
-/// - `+++ ` followed by `@@ ` on the next line (missing `---`)
-fn is_patch_boundary(prev: Option<&str>, line: &str, next: Option<&str>, _mode: ParseMode) -> bool {
+/// * `--- ` followed by `+++ ` on the next line
+/// * `+++ ` followed by `--- ` on the next line
+/// * `--- ` followed by `@@ ` on the next line (missing `+++`)
+/// * `+++ ` followed by `@@ ` on the next line (missing `---`)
+fn is_unidiff_boundary(prev: Option<&str>, line: &str, next: Option<&str>) -> bool {
     if line.starts_with(ORIGINAL_PREFIX) {
         // Make sure it isn't part of a (`+++` / `--- `) pair
         if prev.is_some_and(|p| p.starts_with(MODIFIED_PREFIX)) {
@@ -111,6 +139,29 @@ fn is_patch_boundary(prev: Option<&str>, line: &str, next: Option<&str>, _mode: 
     }
 
     false
+}
+
+/// Strips email preamble (headers and commit message) from `git format-patch` output.
+///
+/// Returns the content after the first `\n---\n` separator.
+/// If no separator is found, returns the entire input.
+///
+/// ## Observed git behavior
+///
+/// `git mailinfo` (used by `git am`) uses the first `---` line
+/// as the separator between commit message and patch content.
+/// It does not check if `diff --git` follows or there are more `---` lines.
+///
+/// From [`git format-patch`] manpage:
+///
+/// > The log message and the patch are separated by a line with a three-dash line.
+///
+/// [`git format-patch`]: https://git-scm.com/docs/git-format-patch>:
+fn strip_email_preamble(input: &str) -> &str {
+    input
+        .split_once(EMAIL_PREAMBLE_SEPARATOR)
+        .map(|(_, after)| after)
+        .unwrap_or(input)
 }
 
 /// Strips trailing email signature (RFC 3676).

--- a/src/patchset/tests.rs
+++ b/src/patchset/tests.rs
@@ -318,6 +318,247 @@ mod extract_file_operation {
     }
 }
 
+mod git_diff_boundary {
+    use super::*;
+
+    #[test]
+    fn diff_git_is_boundary_in_gitdiff_mode() {
+        let content = "\
+diff --git a/file1.rs b/file1.rs
+--- a/file1.rs
++++ b/file1.rs
+@@ -1 +1 @@
+-old1
++new1
+diff --git a/file2.rs b/file2.rs
+--- a/file2.rs
++++ b/file2.rs
+@@ -1 +1 @@
+-old2
++new2
+";
+        let patches = split_patches(content, ParseMode::GitDiff);
+        assert_eq!(patches.len(), 2);
+        assert!(Patch::from_str(patches[0]).is_ok());
+        assert!(Patch::from_str(patches[1]).is_ok());
+    }
+
+    #[test]
+    fn diff_git_not_boundary_in_unidiff_mode() {
+        // In UniDiff mode, `diff --git` is just noise before the real boundary
+        let content = "\
+diff --git a/file1.rs b/file1.rs
+--- a/file1.rs
++++ b/file1.rs
+@@ -1 +1 @@
+-old1
++new1
+diff --git a/file2.rs b/file2.rs
+--- a/file2.rs
++++ b/file2.rs
+@@ -1 +1 @@
+-old2
++new2
+";
+        let patches = split_patches(content, ParseMode::UniDiff);
+        assert_eq!(patches.len(), 2);
+        // Both should parse, the `diff --git` lines are just garbage before `---`
+        assert!(Patch::from_str(patches[0]).is_ok());
+        assert!(Patch::from_str(patches[1]).is_ok());
+    }
+
+    #[test]
+    fn git_headers_do_not_split_patch() {
+        // Git extended headers between `diff --git` and `---` should not cause split
+        let content = "\
+diff --git a/file.rs b/file.rs
+old mode 100644
+new mode 100755
+--- a/file.rs
++++ b/file.rs
+@@ -1 +1 @@
+-old
++new
+";
+        let patches = split_patches(content, ParseMode::GitDiff);
+        assert_eq!(patches.len(), 1);
+        assert!(Patch::from_str(patches[0]).is_ok());
+    }
+
+    #[test]
+    fn new_file_mode_header() {
+        let content = "\
+diff --git a/new.sh b/new.sh
+new file mode 100755
+--- /dev/null
++++ b/new.sh
+@@ -0,0 +1 @@
++content
+";
+        let patches = split_patches(content, ParseMode::GitDiff);
+        assert_eq!(patches.len(), 1);
+        assert!(Patch::from_str(patches[0]).is_ok());
+    }
+
+    #[test]
+    fn deleted_file_mode_header() {
+        let content = "\
+diff --git a/old.sh b/old.sh
+deleted file mode 100755
+--- a/old.sh
++++ /dev/null
+@@ -1 +0,0 @@
+-content
+";
+        let patches = split_patches(content, ParseMode::GitDiff);
+        assert_eq!(patches.len(), 1);
+        assert!(Patch::from_str(patches[0]).is_ok());
+    }
+
+    #[test]
+    fn rename_headers() {
+        let content = "\
+diff --git a/old.txt b/new.txt
+similarity index 100%
+rename from old.txt
+rename to new.txt
+";
+        let patches = split_patches(content, ParseMode::GitDiff);
+        assert_eq!(patches.len(), 0);
+        // Pure rename has no hunks, but should still be one patch slice
+    }
+
+    #[test]
+    fn index_header_recognized() {
+        let content = "\
+diff --git a/file.rs b/file.rs
+index 1234567..89abcdef 100644
+--- a/file.rs
++++ b/file.rs
+@@ -1 +1 @@
+-old
++new
+";
+        let patches = split_patches(content, ParseMode::GitDiff);
+        assert_eq!(patches.len(), 1);
+        assert!(Patch::from_str(patches[0]).is_ok());
+    }
+
+    #[test]
+    fn commit_message_with_diff_git_text_inline() {
+        // Only the real "diff --git" at line start is detected
+        let content = "\
+From abc123 Mon Sep 17 00:00:00 2001
+From: Test <test@test.com>
+Subject: [PATCH] test
+
+This commit message mentions diff --git a/fake b/fake as example.
+
+---
+ file.rs | 1 +
+
+diff --git a/file.rs b/file.rs
+--- a/file.rs
++++ b/file.rs
+@@ -1 +1,2 @@
+ real
++change
+";
+        let patches = split_patches(content, ParseMode::GitDiff);
+        assert_eq!(patches.len(), 1);
+        assert!(Patch::from_str(patches[0]).is_ok());
+    }
+
+    #[test]
+    fn commit_message_with_diff_git_at_line_start() {
+        // "diff --git" in commit message is ignored because we strip the email preamble.
+        // This is an observed git behavior. See `strip_email_preamble`.
+        let content = "\
+From abc123 Mon Sep 17 00:00:00 2001
+Subject: [PATCH] test
+
+Example of a diff line:
+diff --git a/fake b/fake
+This is not a real diff.
+
+---
+ file.rs | 1 +
+
+diff --git a/file.rs b/file.rs
+--- a/file.rs
++++ b/file.rs
+@@ -1 +1,2 @@
+ real
++change
+";
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+        assert!(patchset.patches()[0].operation().is_modify());
+    }
+
+    #[test]
+    fn multiple_separator_and_diff_git_in_commit_message() {
+        // Git uses the first `---` as separator,
+        // so the fake ones are included in patch.
+        //
+        // This is an observed git behavior. See `strip_email_preamble`.
+        let content = "\
+From abc123 Mon Sep 17 00:00:00 2001
+Subject: [PATCH] test
+
+Here is an example:
+---
+diff --git a/fake b/fake
+This is not real.
+---
+ real.rs | 1 +
+
+diff --git a/real.rs b/real.rs
+--- a/real.rs
++++ b/real.rs
+@@ -1 +1,2 @@
+ real
++change
+";
+        let patches = split_patches(content, ParseMode::GitDiff);
+        // First `---` is used as separator,
+        // so both fake and real `diff --git` are detected as patches.
+        assert_eq!(patches.len(), 1);
+        assert!(!patches[0].contains("diff --git a/fake"));
+        // assert!(patches[1].contains("diff --git a/real.rs"));
+    }
+
+    #[test]
+    fn multiple_patches_with_various_headers() {
+        let content = "\
+diff --git a/file1.rs b/file1.rs
+index 1111111..2222222 100644
+--- a/file1.rs
++++ b/file1.rs
+@@ -1 +1 @@
+-old1
++new1
+diff --git a/file2.rs b/file2.rs
+new file mode 100644
+--- /dev/null
++++ b/file2.rs
+@@ -0,0 +1 @@
++new file
+diff --git a/file3.rs b/file3.rs
+deleted file mode 100644
+--- a/file3.rs
++++ /dev/null
+@@ -1 +0,0 @@
+-deleted
+";
+        let patches = split_patches(content, ParseMode::GitDiff);
+        assert_eq!(patches.len(), 3);
+        assert!(Patch::from_str(patches[0]).is_ok());
+        assert!(Patch::from_str(patches[1]).is_ok());
+        assert!(Patch::from_str(patches[2]).is_ok());
+    }
+}
+
 mod patchset {
     use super::*;
 

--- a/src/patchset/tests.rs
+++ b/src/patchset/tests.rs
@@ -424,7 +424,7 @@ rename from old.txt
 rename to new.txt
 ";
         let patches = split_patches(content, ParseMode::GitDiff);
-        assert_eq!(patches.len(), 0);
+        assert_eq!(patches.len(), 1);
         // Pure rename has no hunks, but should still be one patch slice
     }
 
@@ -523,9 +523,9 @@ diff --git a/real.rs b/real.rs
         let patches = split_patches(content, ParseMode::GitDiff);
         // First `---` is used as separator,
         // so both fake and real `diff --git` are detected as patches.
-        assert_eq!(patches.len(), 1);
-        assert!(!patches[0].contains("diff --git a/fake"));
-        // assert!(patches[1].contains("diff --git a/real.rs"));
+        assert_eq!(patches.len(), 2);
+        assert!(patches[0].contains("diff --git a/fake"));
+        assert!(patches[1].contains("diff --git a/real.rs"));
     }
 
     #[test]

--- a/tests/git_history_replay.rs
+++ b/tests/git_history_replay.rs
@@ -167,7 +167,12 @@ fn process_commit(
     let mut applied = 0;
     let mut skipped = 0;
 
-    let diff_output = git(repo, &["diff", parent, child]);
+    // UniDiff format cannot express pure renames (no ---/+++ headers).
+    // Use `--no-renames` to represent them as delete + create instead.
+    let diff_output = match mode {
+        ParseMode::UniDiff => git(repo, &["diff", "--no-renames", parent, child]),
+        ParseMode::GitDiff => git(repo, &["diff", parent, child]),
+    };
 
     if diff_output.is_empty() {
         // No changes (could be metadata-only commit)
@@ -190,6 +195,28 @@ fn process_commit(
             );
         }
     };
+
+    // Verify we parsed the same number of patches as git reports files changed.
+    // This catches cases where patches are silently skipped.
+    let expected_file_count = match mode {
+        ParseMode::UniDiff => git(
+            repo,
+            &["diff", "--name-status", "--no-renames", parent, child],
+        ),
+        ParseMode::GitDiff => git(repo, &["diff", "--name-status", parent, child]),
+    }
+    .lines()
+    .filter(|l| !l.is_empty())
+    .count();
+
+    if patchset.len() != expected_file_count {
+        let n = patchset.len();
+        panic!(
+            "Patch count mismatch for {parent_short}..{child_short}: \
+             expected {expected_file_count} files, parsed {n} patches\n\n\
+             Diff:\n{diff_output}",
+        );
+    }
 
     for file_patch in patchset.iter() {
         let operation = file_patch.operation().strip_prefix(1);

--- a/tests/git_history_replay.rs
+++ b/tests/git_history_replay.rs
@@ -12,6 +12,8 @@
 //!   Defaults to the package directory (`CARGO_MANIFEST_DIR`).
 //! * `DIFFY_TEST_COMMITS`: Maximum number of commits to verify.
 //!   Defaults to 200. Use `0` to verify entire history.
+//! * `DIFFY_TEST_PARSE_MODE`: Parse mode to use (`unidiff` or `gitdiff`).
+//!   Defaults to `unidiff`.
 //!
 //! ## Requirements
 //!
@@ -56,6 +58,17 @@ fn max_commits() -> usize {
     } else {
         val.parse()
             .unwrap_or_else(|e| panic!("invalid DIFFY_TEST_COMMITS='{val}': {e}"))
+    }
+}
+
+fn parse_mode() -> ParseMode {
+    let Ok(val) = env::var("DIFFY_TEST_PARSE_MODE") else {
+        return ParseMode::UniDiff;
+    };
+    match val.trim().to_lowercase().as_str() {
+        "unidiff" => ParseMode::UniDiff,
+        "gitdiff" => ParseMode::GitDiff,
+        _ => panic!("invalid DIFFY_TEST_PARSE_MODE='{val}': expected 'unidiff' or 'gitdiff'"),
     }
 }
 
@@ -124,13 +137,15 @@ fn file_at_commit(repo: &PathBuf, commit: &str, path: &str) -> Option<String> {
 /// Get the list of commits from oldest to newest.
 fn commit_history(repo: &PathBuf, max: usize) -> Vec<String> {
     // We want newest N in chronological order, so: fetch newest, then reverse.
+    // Use --first-parent to ensure consecutive commits are actual parent-child pairs,
+    // not unrelated commits from different branches before a merge.
     let output = if max == usize::MAX {
-        git(repo, &["rev-list", "--reverse", "HEAD"])
+        git(repo, &["rev-list", "--first-parent", "--reverse", "HEAD"])
     } else {
         // fetches only the most recent `max + 1` commits
         // to have `max` commit pairs for diffing.
         let n = (max + 1).to_string();
-        git(repo, &["rev-list", "-n", &n, "HEAD"])
+        git(repo, &["rev-list", "--first-parent", "-n", &n, "HEAD"])
     };
     let mut commits: Vec<_> = output.lines().map(String::from).collect();
     if max != usize::MAX {
@@ -139,7 +154,13 @@ fn commit_history(repo: &PathBuf, max: usize) -> Vec<String> {
     commits
 }
 
-fn process_commit(repo: &PathBuf, idx: usize, parent: &str, child: &str) -> CommitResult {
+fn process_commit(
+    repo: &PathBuf,
+    idx: usize,
+    parent: &str,
+    child: &str,
+    mode: ParseMode,
+) -> CommitResult {
     let parent_short = parent[..8].to_string();
     let child_short = child[..8].to_string();
     let mut files = Vec::new();
@@ -160,7 +181,7 @@ fn process_commit(repo: &PathBuf, idx: usize, parent: &str, child: &str) -> Comm
         };
     }
 
-    let patchset = match PatchSet::parse(&diff_output, ParseMode::UniDiff) {
+    let patchset = match PatchSet::parse(&diff_output, mode) {
         Ok(ps) => ps,
         Err(e) => {
             panic!(
@@ -245,6 +266,7 @@ fn process_commit(repo: &PathBuf, idx: usize, parent: &str, child: &str) -> Comm
 fn test_git_history_replay() {
     let repo = repo_path();
     let max = max_commits();
+    let mode = parse_mode();
     let commits = commit_history(&repo, max);
 
     if commits.len() < 2 {
@@ -257,6 +279,10 @@ fn test_git_history_replay() {
         .file_name()
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_else(|| ".".to_string());
+    let mode_name = match mode {
+        ParseMode::UniDiff => "unidiff",
+        ParseMode::GitDiff => "gitdiff",
+    };
 
     let (tx, rx) = mpsc::channel::<CommitResult>();
     let repo = &repo;
@@ -268,7 +294,7 @@ fn test_git_history_replay() {
             let child = &window[1];
 
             s.spawn(move || {
-                let result = process_commit(repo, i, parent, child);
+                let result = process_commit(repo, i, parent, child, mode);
                 tx.send(result).expect("failed to send result");
             });
         }
@@ -284,7 +310,7 @@ fn test_git_history_replay() {
         for result in results {
             let idx = result.idx + 1;
             eprintln!(
-                "[{idx}/{total_diffs}] ({repo_name}) Processing {}..{}",
+                "[{idx}/{total_diffs}] ({repo_name}, {mode_name}) Processing {}..{}",
                 result.parent_short, result.child_short
             );
             for desc in &result.files {


### PR DESCRIPTION
Add GitDiff mode that:

* Uses `diff --git` as the only patch boundary
* Strips email preamble (content before first `\n---\n` separator)

This matches observed git behavior where `git mailinfo` uses the
first `---` line as separator between commit message and patch.