### PR TITLE
refactor(patchset): expand `FileOperation` with `Rename` and `Copy`

### DIFF
--- a/src/patchset/mod.rs
+++ b/src/patchset/mod.rs
@@ -175,18 +175,28 @@ impl<'a, T: ToOwned + ?Sized> FilePatch<'a, T> {
 /// The operation to perform based on a patch.
 ///
 /// This is determined by examining the `---` and `+++` header lines
-/// of a unified diff patch.
+/// of a unified diff patch, and git extended headers when available.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FileOperation {
     /// Delete a file (`+++ /dev/null`).
     Delete(String),
     /// Create a new file (`--- /dev/null`).
     Create(String),
-    /// Modify or rename a file.
+    /// Modify a file.
     ///
-    /// * `from == to` → modify file in place
-    /// * `from != to` → rename (read from `from`, write to `to`, delete `from`)
-    Modify { from: String, to: String },
+    /// * If `original == modified`, this is an in-place modification.
+    /// * If they differ, the caller decides how to handle, e.g., treat as rename or error.
+    ///
+    /// Usually, the caller needs to strip the prefix from the paths to determine.
+    Modify { original: String, modified: String },
+    /// Rename a file (move from `from` to `to`, delete `from`).
+    ///
+    /// Only produced when git extended headers explicitly indicate a rename.
+    Rename { from: String, to: String },
+    /// Copy a file (copy from `from` to `to`, keep `from`).
+    ///
+    /// Only produced when git extended headers explicitly indicate a copy.
+    Copy { from: String, to: String },
 }
 
 impl FileOperation {
@@ -209,7 +219,15 @@ impl FileOperation {
         match self {
             FileOperation::Delete(path) => FileOperation::Delete(strip(path, n)),
             FileOperation::Create(path) => FileOperation::Create(strip(path, n)),
-            FileOperation::Modify { from, to } => FileOperation::Modify {
+            FileOperation::Modify { original, modified } => FileOperation::Modify {
+                original: strip(original, n),
+                modified: strip(modified, n),
+            },
+            FileOperation::Rename { from, to } => FileOperation::Rename {
+                from: strip(from, n),
+                to: strip(to, n),
+            },
+            FileOperation::Copy { from, to } => FileOperation::Copy {
                 from: strip(from, n),
                 to: strip(to, n),
             },
@@ -226,13 +244,18 @@ impl FileOperation {
         matches!(self, FileOperation::Delete(_))
     }
 
-    /// Returns `true` if this is a file modification (including rename).
+    /// Returns `true` if this is a file modification.
     pub fn is_modify(&self) -> bool {
         matches!(self, FileOperation::Modify { .. })
     }
 
-    /// Returns `true` if this is a rename operation (modify where `from != to`).
+    /// Returns `true` if this is a rename operation.
     pub fn is_rename(&self) -> bool {
-        matches!(self, FileOperation::Modify { from, to } if from != to)
+        matches!(self, FileOperation::Rename { .. })
+    }
+
+    /// Returns `true` if this is a copy operation.
+    pub fn is_copy(&self) -> bool {
+        matches!(self, FileOperation::Copy { .. })
     }
 }

--- a/src/patchset/parse.rs
+++ b/src/patchset/parse.rs
@@ -205,22 +205,25 @@ pub fn extract_file_operation(
         Ok(FileOperation::Create(path.to_owned()))
     } else {
         match (original, modified) {
-            (Some(from), Some(to)) => Ok(FileOperation::Modify {
-                from: from.to_owned(),
-                to: to.to_owned(),
+            (Some(original), Some(modified)) => Ok(FileOperation::Modify {
+                original: original.to_owned(),
+                modified: modified.to_owned(),
             }),
-            (None, Some(to)) => {
+            (None, Some(modified)) => {
                 // No original path, but has modified path.
-                // This is a modify operation (not create) - GNU patch reads from the modified path.
+                // Observed that GNU patch reads from the modified path in this case.
                 Ok(FileOperation::Modify {
-                    from: to.to_owned(),
-                    to: to.to_owned(),
+                    original: modified.to_owned(),
+                    modified: modified.to_owned(),
                 })
             }
-            (Some(from), None) => Ok(FileOperation::Modify {
-                from: from.to_owned(),
-                to: from.to_owned(),
-            }),
+            (Some(original), None) => {
+                // No modified path, but has original path.
+                Ok(FileOperation::Modify {
+                    original: original.to_owned(),
+                    modified: original.to_owned(),
+                })
+            }
             (None, None) => Err(ParsePatchError::new("patch has no file path")),
         }
     }

--- a/src/patchset/tests.rs
+++ b/src/patchset/tests.rs
@@ -10,15 +10,15 @@ mod file_operation {
     #[test]
     fn test_strip_prefix() {
         let op = FileOperation::Modify {
-            from: "a/src/lib.rs".to_owned(),
-            to: "b/src/lib.rs".to_owned(),
+            original: "a/src/lib.rs".to_owned(),
+            modified: "b/src/lib.rs".to_owned(),
         };
         let stripped = op.strip_prefix(1);
         assert_eq!(
             stripped,
             FileOperation::Modify {
-                from: "src/lib.rs".to_owned(),
-                to: "src/lib.rs".to_owned(),
+                original: "src/lib.rs".to_owned(),
+                modified: "src/lib.rs".to_owned(),
             }
         );
     }
@@ -28,21 +28,6 @@ mod file_operation {
         let op = FileOperation::Create("file.rs".to_owned());
         let stripped = op.strip_prefix(1);
         assert_eq!(stripped, FileOperation::Create("file.rs".to_owned()));
-    }
-
-    #[test]
-    fn test_is_rename() {
-        let modify_same = FileOperation::Modify {
-            from: "file.rs".to_owned(),
-            to: "file.rs".to_owned(),
-        };
-        assert!(!modify_same.is_rename());
-
-        let rename = FileOperation::Modify {
-            from: "old.rs".to_owned(),
-            to: "new.rs".to_owned(),
-        };
-        assert!(rename.is_rename());
     }
 }
 
@@ -251,8 +236,8 @@ mod extract_file_operation {
         assert_eq!(
             op,
             FileOperation::Modify {
-                from: "a/src/lib.rs".to_owned(),
-                to: "b/src/lib.rs".to_owned(),
+                original: "a/src/lib.rs".to_owned(),
+                modified: "b/src/lib.rs".to_owned(),
             }
         );
     }
@@ -270,13 +255,13 @@ mod extract_file_operation {
     }
 
     #[test]
-    fn rename() {
+    fn different_paths() {
         let op = extract_file_operation(Some("a/old_name.rs"), Some("b/new_name.rs")).unwrap();
         assert_eq!(
             op,
             FileOperation::Modify {
-                from: "a/old_name.rs".to_owned(),
-                to: "b/new_name.rs".to_owned(),
+                original: "a/old_name.rs".to_owned(),
+                modified: "b/new_name.rs".to_owned(),
             }
         );
     }
@@ -287,8 +272,8 @@ mod extract_file_operation {
         assert_eq!(
             op,
             FileOperation::Modify {
-                from: "a/src/lib.rs".to_owned(),
-                to: "a/src/lib.rs".to_owned(),
+                original: "a/src/lib.rs".to_owned(),
+                modified: "a/src/lib.rs".to_owned(),
             }
         );
     }
@@ -299,8 +284,8 @@ mod extract_file_operation {
         assert_eq!(
             op,
             FileOperation::Modify {
-                from: "b/src/lib.rs".to_owned(),
-                to: "b/src/lib.rs".to_owned(),
+                original: "b/src/lib.rs".to_owned(),
+                modified: "b/src/lib.rs".to_owned(),
             }
         );
     }
@@ -608,7 +593,7 @@ mod patchset {
     }
 
     #[test]
-    fn patchset_rename() {
+    fn patchset_different_paths() {
         let content = "\
 --- a/old_name.rs
 +++ b/new_name.rs
@@ -619,7 +604,16 @@ mod patchset {
         let patchset = PatchSet::parse(content, ParseMode::UniDiff).unwrap();
         assert_eq!(patchset.len(), 1);
 
+        // Different paths produce Modify, not Rename.
+        // Rename is only produced from explicit git headers.
         let op = patchset.patches()[0].operation();
-        assert!(op.is_rename());
+        assert!(op.is_modify());
+        assert_eq!(
+            op,
+            &FileOperation::Modify {
+                original: "a/old_name.rs".to_owned(),
+                modified: "b/new_name.rs".to_owned(),
+            }
+        );
     }
 }

--- a/tests/git_history_replay.rs
+++ b/tests/git_history_replay.rs
@@ -236,7 +236,23 @@ fn process_commit(
                 };
                 (base, String::new(), format!("delete {path}"))
             }
-            FileOperation::Modify { from, to } => {
+            FileOperation::Modify { original, modified } => {
+                let Some(base) = file_at_commit(repo, parent, original) else {
+                    skipped += 1;
+                    continue;
+                };
+                let Some(expected) = file_at_commit(repo, child, modified) else {
+                    skipped += 1;
+                    continue;
+                };
+                let desc = if original == modified {
+                    format!("modify {original}")
+                } else {
+                    format!("modify {original} -> {modified}")
+                };
+                (base, expected, desc)
+            }
+            FileOperation::Rename { from, to } => {
                 let Some(base) = file_at_commit(repo, parent, from) else {
                     skipped += 1;
                     continue;
@@ -245,12 +261,18 @@ fn process_commit(
                     skipped += 1;
                     continue;
                 };
-                let desc = if from == to {
-                    format!("modify {from}")
-                } else {
-                    format!("rename {from} -> {to}")
+                (base, expected, format!("rename {from} -> {to}"))
+            }
+            FileOperation::Copy { from, to } => {
+                let Some(base) = file_at_commit(repo, parent, from) else {
+                    skipped += 1;
+                    continue;
                 };
-                (base, expected, desc)
+                let Some(expected) = file_at_commit(repo, child, to) else {
+                    skipped += 1;
+                    continue;
+                };
+                (base, expected, format!("copy {from} -> {to}"))
             }
         };
 


### PR DESCRIPTION
New variants:

- `Rename { from, to }` for file moves
- `Copy { from, to }` for file duplicates

These are used for future `GitDiff` parse mode