### PR TITLE
feat(patchset): git extended header extraction

### DIFF
--- a/src/patchset/parse.rs
+++ b/src/patchset/parse.rs
@@ -128,7 +128,6 @@ fn is_unidiff_boundary(prev: Option<&str>, line: &str, next: Option<&str>) -> bo
 /// Strips email preamble (headers and commit message) from `git format-patch` output.
 ///
 /// Returns the content after the first `\n---\n` separator.
-/// If no separator is found, returns the entire input.
 ///
 /// ## Observed git behavior
 ///
@@ -140,12 +139,12 @@ fn is_unidiff_boundary(prev: Option<&str>, line: &str, next: Option<&str>) -> bo
 ///
 /// > The log message and the patch are separated by a line with a three-dash line.
 ///
-/// [`git format-patch`]: https://git-scm.com/docs/git-format-patch>:
+/// [`git format-patch`]: https://git-scm.com/docs/git-format-patch
 fn strip_email_preamble(input: &str) -> &str {
-    input
-        .split_once(EMAIL_PREAMBLE_SEPARATOR)
-        .map(|(_, after)| after)
-        .unwrap_or(input)
+    match input.find(EMAIL_PREAMBLE_SEPARATOR) {
+        Some(pos) => &input[pos + EMAIL_PREAMBLE_SEPARATOR.len()..],
+        None => input,
+    }
 }
 
 /// Strips trailing email signature (RFC 3676).

--- a/src/patchset/parse.rs
+++ b/src/patchset/parse.rs
@@ -12,44 +12,36 @@ const HUNK_PREFIX: &str = "@@ ";
 /// Path used to indicate file creation or deletion.
 const DEV_NULL: &str = "/dev/null";
 
-/// Prefix for git diff header (e.g., `diff --git a/file b/file`).
-const GIT_DIFF_PREFIX: &str = "diff --git ";
-
 /// Separator between commit message and patch in git format-patch output.
 const EMAIL_PREAMBLE_SEPARATOR: &str = "\n---\n";
 
 /// Parse a multi-file patch.
-///
-/// This strips:
-///
-/// * email preamble (headers and commit message before `---` separator)
-/// * trailing email signature
 pub fn parse(input: &str, mode: ParseMode) -> Result<PatchSet<'_, str>, ParsePatchError> {
     // Email signatures would be parsed as a delete line and corrupt the hunk.
     // Must strip before parsing.
     let input = strip_email_signature(input);
 
-    // In GitDiff mode, strip email preamble to avoid false `diff --git` matches
-    // in commit messages.
-    let input = match mode {
-        ParseMode::GitDiff => strip_email_preamble(input),
-        ParseMode::UniDiff => input,
-    };
+    match mode {
+        ParseMode::GitDiff => parse_unidiff(strip_email_preamble(input)),
+        ParseMode::UniDiff => parse_unidiff(input),
+    }
+}
 
-    let patch_strs = split_patches(input, mode);
+fn parse_unidiff(input: &str) -> Result<PatchSet<'_, str>, ParsePatchError> {
+    let patch_strs = split_patches_unidiff(input);
 
     let mut patches = Vec::with_capacity(patch_strs.len());
     for patch_str in patch_strs {
         let patch = Patch::from_str(patch_str)?;
-        let operation = extract_file_operation(patch.original(), patch.modified())?;
+        let operation = extract_file_op_unidiff(patch.original(), patch.modified())?;
         patches.push(FilePatch::new(operation, patch));
     }
 
     Ok(PatchSet::new(patches))
 }
 
-/// Splits a unified diff containing multiple file patches.
-pub fn split_patches(content: &str, mode: ParseMode) -> Vec<&str> {
+/// Splits a unified diff containing multiple file patches (UniDiff mode).
+pub(crate) fn split_patches_unidiff(content: &str) -> Vec<&str> {
     let mut patches = Vec::new();
     let mut patch_start = None::<usize>;
     let mut prev_line = None::<&str>;
@@ -60,7 +52,7 @@ pub fn split_patches(content: &str, mode: ParseMode) -> Vec<&str> {
     while let Some(line) = lines.next() {
         let next_line = lines.peek().copied();
 
-        if is_patch_boundary(prev_line, line, next_line, mode) {
+        if is_unidiff_boundary(prev_line, line, next_line) {
             if let Some(start) = patch_start {
                 patches.push(&content[start..byte_offset]);
             }
@@ -84,19 +76,11 @@ pub fn split_patches(content: &str, mode: ParseMode) -> Vec<&str> {
     patches
 }
 
-/// Checks if the current line is a patch boundary.
-fn is_patch_boundary(prev: Option<&str>, line: &str, next: Option<&str>, mode: ParseMode) -> bool {
-    match mode {
-        ParseMode::GitDiff => is_gitdiff_boundary(line),
-        ParseMode::UniDiff => is_unidiff_boundary(prev, line, next),
-    }
-}
-
 /// Checks if the current line is a patch boundary in GitDiff mode.
 ///
 /// Only `diff --git ` is recognized as a boundary.
 fn is_gitdiff_boundary(line: &str) -> bool {
-    line.starts_with(GIT_DIFF_PREFIX)
+    line.starts_with("diff --git ")
 }
 
 /// Checks if the current line is a patch boundary in UniDiff mode.
@@ -184,7 +168,7 @@ fn strip_email_signature(input: &str) -> &str {
 }
 
 /// Extracts the file operation from a patch based on its header paths.
-pub fn extract_file_operation(
+pub fn extract_file_op_unidiff(
     original: Option<&str>,
     modified: Option<&str>,
 ) -> Result<FileOperation, ParsePatchError> {

--- a/src/patchset/parse.rs
+++ b/src/patchset/parse.rs
@@ -22,9 +22,24 @@ pub fn parse(input: &str, mode: ParseMode) -> Result<PatchSet<'_, str>, ParsePat
     let input = strip_email_signature(input);
 
     match mode {
-        ParseMode::GitDiff => parse_unidiff(strip_email_preamble(input)),
+        ParseMode::GitDiff => parse_gitdiff(input),
         ParseMode::UniDiff => parse_unidiff(input),
     }
+}
+
+fn parse_gitdiff(input: &str) -> Result<PatchSet<'_, str>, ParsePatchError> {
+    // Strip email preamble to avoid false `diff --git` matches in commit messages.
+    let input = strip_email_preamble(input);
+
+    let mut patches = Vec::new();
+    for raw in split_patches_gitdiff(input) {
+        let header = GitHeader::parse(raw.header);
+        let patch = Patch::from_str(raw.patch)?;
+        let operation = extract_file_op_gitdiff(header.as_ref(), &patch)?;
+        patches.push(FilePatch::new(operation, patch));
+    }
+
+    Ok(PatchSet::new(patches))
 }
 
 fn parse_unidiff(input: &str) -> Result<PatchSet<'_, str>, ParsePatchError> {
@@ -38,6 +53,45 @@ fn parse_unidiff(input: &str) -> Result<PatchSet<'_, str>, ParsePatchError> {
     }
 
     Ok(PatchSet::new(patches))
+}
+
+/// Splits a git diff containing multiple file patches (GitDiff mode).
+///
+/// Content should be email preamble stripped.
+pub(crate) fn split_patches_gitdiff(content: &str) -> Vec<GitDiff<'_>> {
+    let mut patches = Vec::new();
+    let mut patch_start = None::<usize>;
+    let mut header_end = None::<usize>; // byte offset where `---` was found
+    let mut byte_offset = 0;
+
+    for line in content.lines() {
+        if is_gitdiff_boundary(line) {
+            if let Some(start) = patch_start {
+                patches.push(GitDiff::new(content, start, byte_offset, header_end));
+            }
+            patch_start = Some(byte_offset);
+            header_end = None;
+        } else if line.starts_with(ORIGINAL_PREFIX) && header_end.is_none() {
+            // First `---` after `diff --git` marks end of extended header
+            // Assumption: `git format-patch` always has `---` when starting patch
+            // TODO: add compat tests check whether git may produce other prefix.
+            header_end = Some(byte_offset);
+        }
+
+        byte_offset += line.len();
+
+        if content[byte_offset..].starts_with("\r\n") {
+            byte_offset += 2;
+        } else if content[byte_offset..].starts_with('\n') {
+            byte_offset += 1;
+        }
+    }
+
+    if let Some(start) = patch_start {
+        patches.push(GitDiff::new(content, start, content.len(), header_end));
+    }
+
+    patches
 }
 
 /// Splits a unified diff containing multiple file patches (UniDiff mode).
@@ -80,6 +134,7 @@ pub(crate) fn split_patches_unidiff(content: &str) -> Vec<&str> {
 ///
 /// Only `diff --git ` is recognized as a boundary.
 fn is_gitdiff_boundary(line: &str) -> bool {
+    // TODO: add compat tests verifying this matches how git works
     line.starts_with("diff --git ")
 }
 
@@ -211,5 +266,110 @@ pub fn extract_file_op_unidiff(
             }
             (None, None) => Err(ParsePatchError::new("patch has no file path")),
         }
+    }
+}
+
+/// Determines the file operation using git headers (if available) and patch paths.
+fn extract_file_op_gitdiff(
+    header: Option<&GitHeader<'_>>,
+    patch: &Patch<'_, str>,
+) -> Result<FileOperation, ParsePatchError> {
+    // Git headers are authoritative for rename/copy
+    if let Some(h) = header {
+        if let (Some(from), Some(to)) = (h.rename_from, h.rename_to) {
+            return Ok(FileOperation::Rename {
+                from: from.to_owned(),
+                to: to.to_owned(),
+            });
+        }
+        if let (Some(from), Some(to)) = (h.copy_from, h.copy_to) {
+            return Ok(FileOperation::Copy {
+                from: from.to_owned(),
+                to: to.to_owned(),
+            });
+        }
+    }
+
+    // Fall back to ---/+++ paths
+    extract_file_op_unidiff(patch.original(), patch.modified())
+}
+
+/// A single file's patch split into header and unified diff sections.
+#[derive(Debug)]
+pub(crate) struct GitDiff<'a> {
+    /// Lines between `diff --git` and `---` (extended header).
+    pub header: &'a str,
+    /// The unified diff content (`---`/`+++` and hunks).
+    ///
+    /// For pure renames/mode-only changes, this is empty.
+    pub patch: &'a str,
+}
+
+impl<'a> GitDiff<'a> {
+    /// Creates a GitDiff from a content slice and byte offsets.
+    fn new(
+        content: &'a str,
+        patch_start: usize,
+        patch_end: usize,
+        header_end: Option<usize>,
+    ) -> Self {
+        let patch = &content[patch_start..patch_end];
+        match header_end {
+            Some(end) => {
+                let header_len = end - patch_start;
+                GitDiff {
+                    header: &patch[..header_len],
+                    patch: &patch[header_len..],
+                }
+            }
+            None => {
+                // No `---` found: pure rename/mode-change/binary — all header
+                GitDiff {
+                    header: patch,
+                    patch: "",
+                }
+            }
+        }
+    }
+}
+
+/// Git extended header metadata.
+///
+/// Extracted from lines between `diff --git` and `---` (or end of patch).
+/// See [git-diff format documentation](https://git-scm.com/docs/diff-format).
+#[derive(Debug, Default, PartialEq, Eq)]
+pub(crate) struct GitHeader<'a> {
+    pub(crate) rename_from: Option<&'a str>,
+    pub(crate) rename_to: Option<&'a str>,
+    pub(crate) copy_from: Option<&'a str>,
+    pub(crate) copy_to: Option<&'a str>,
+}
+
+impl<'a> GitHeader<'a> {
+    /// Parses git extended header metadata from a pre-split header string.
+    ///
+    /// Returns `None` if no recognizable git headers are found.
+    pub(crate) fn parse(header_str: &'a str) -> Option<Self> {
+        let mut header = GitHeader::default();
+        let mut found_any = false;
+
+        for line in header_str.lines() {
+            if let Some(path) = line.strip_prefix("rename from ") {
+                header.rename_from = Some(path);
+                found_any = true;
+            } else if let Some(path) = line.strip_prefix("rename to ") {
+                header.rename_to = Some(path);
+                found_any = true;
+            } else if let Some(path) = line.strip_prefix("copy from ") {
+                header.copy_from = Some(path);
+                found_any = true;
+            } else if let Some(path) = line.strip_prefix("copy to ") {
+                header.copy_to = Some(path);
+                found_any = true;
+            }
+            // TODO: old mode, new mode, similarity index, dissimilarity index, index <hash>..<hash>
+        }
+
+        found_any.then_some(header)
     }
 }

--- a/src/patchset/tests.rs
+++ b/src/patchset/tests.rs
@@ -1,6 +1,7 @@
 //! Tests for patchset parsing.
 
-use super::parse::{extract_file_operation, split_patches};
+use super::parse::extract_file_op_unidiff;
+use super::parse::split_patches_unidiff;
 use super::{FileOperation, ParseMode, PatchSet};
 use crate::Patch;
 
@@ -45,7 +46,7 @@ mod split_patches {
 +line3
  line4
 ";
-        let patches = split_patches(content, ParseMode::UniDiff);
+        let patches = split_patches_unidiff(content);
         assert_eq!(patches.len(), 1);
         assert!(Patch::from_str(patches[0]).is_ok());
     }
@@ -64,7 +65,7 @@ mod split_patches {
 -old2
 +new2
 ";
-        let patches = split_patches(content, ParseMode::UniDiff);
+        let patches = split_patches_unidiff(content);
         assert_eq!(patches.len(), 2);
         assert!(Patch::from_str(patches[0]).is_ok());
         assert!(Patch::from_str(patches[1]).is_ok());
@@ -81,7 +82,7 @@ It should be ignored
 -old
 +new
 ";
-        let patches = split_patches(content, ParseMode::UniDiff);
+        let patches = split_patches_unidiff(content);
         assert_eq!(patches.len(), 1);
         assert!(Patch::from_str(patches[0]).is_ok());
     }
@@ -98,14 +99,14 @@ It should be ignored
 +--- this line starts with dashes
  line3
 ";
-        let patches = split_patches(content, ParseMode::UniDiff);
+        let patches = split_patches_unidiff(content);
         assert_eq!(patches.len(), 1);
         assert!(Patch::from_str(patches[0]).is_ok());
     }
 
     #[test]
     fn split_empty_content() {
-        let patches = split_patches("", ParseMode::UniDiff);
+        let patches = split_patches_unidiff("");
         assert!(patches.is_empty());
     }
 
@@ -146,7 +147,7 @@ In a hole in the ground there lived a hobbit
     #[test]
     fn not_a_patch() {
         let content = "Some random text\nNo patches here\n";
-        let patches = split_patches(content, ParseMode::UniDiff);
+        let patches = split_patches_unidiff(content);
         assert!(patches.is_empty());
     }
 
@@ -158,7 +159,7 @@ In a hole in the ground there lived a hobbit
 Some random text
 No patches here
 ";
-        let patches = split_patches(content, ParseMode::UniDiff);
+        let patches = split_patches_unidiff(content);
         assert!(patches.is_empty());
     }
 
@@ -170,7 +171,7 @@ No patches here
 -old
 +new
 ";
-        let patches = split_patches(content, ParseMode::UniDiff);
+        let patches = split_patches_unidiff(content);
         assert_eq!(patches.len(), 1);
         assert!(Patch::from_str(patches[0]).is_ok());
     }
@@ -183,7 +184,7 @@ No patches here
 -old
 +new
 ";
-        let patches = split_patches(content, ParseMode::UniDiff);
+        let patches = split_patches_unidiff(content);
         assert_eq!(patches.len(), 1);
         assert!(Patch::from_str(patches[0]).is_ok());
     }
@@ -197,7 +198,7 @@ No patches here
 -old
 +new
 ";
-        let patches = split_patches(content, ParseMode::UniDiff);
+        let patches = split_patches_unidiff(content);
         assert_eq!(patches.len(), 1);
         assert!(Patch::from_str(patches[0]).is_ok());
     }
@@ -219,7 +220,7 @@ No patches here
 -old3
 +new3
 ";
-        let patches = split_patches(content, ParseMode::UniDiff);
+        let patches = split_patches_unidiff(content);
         assert_eq!(patches.len(), 3);
         assert!(Patch::from_str(patches[0]).is_ok());
         assert!(Patch::from_str(patches[1]).is_ok());
@@ -227,12 +228,12 @@ No patches here
     }
 }
 
-mod extract_file_operation {
+mod extract_file_op_unidiff {
     use super::*;
 
     #[test]
     fn modify() {
-        let op = extract_file_operation(Some("a/src/lib.rs"), Some("b/src/lib.rs")).unwrap();
+        let op = extract_file_op_unidiff(Some("a/src/lib.rs"), Some("b/src/lib.rs")).unwrap();
         assert_eq!(
             op,
             FileOperation::Modify {
@@ -244,19 +245,19 @@ mod extract_file_operation {
 
     #[test]
     fn new_file() {
-        let op = extract_file_operation(Some("/dev/null"), Some("b/src/lib.rs")).unwrap();
+        let op = extract_file_op_unidiff(Some("/dev/null"), Some("b/src/lib.rs")).unwrap();
         assert_eq!(op, FileOperation::Create("b/src/lib.rs".to_owned()));
     }
 
     #[test]
     fn delete_file() {
-        let op = extract_file_operation(Some("a/src/lib.rs"), Some("/dev/null")).unwrap();
+        let op = extract_file_op_unidiff(Some("a/src/lib.rs"), Some("/dev/null")).unwrap();
         assert_eq!(op, FileOperation::Delete("a/src/lib.rs".to_owned()));
     }
 
     #[test]
     fn different_paths() {
-        let op = extract_file_operation(Some("a/old_name.rs"), Some("b/new_name.rs")).unwrap();
+        let op = extract_file_op_unidiff(Some("a/old_name.rs"), Some("b/new_name.rs")).unwrap();
         assert_eq!(
             op,
             FileOperation::Modify {
@@ -268,7 +269,7 @@ mod extract_file_operation {
 
     #[test]
     fn missing_modified_uses_original() {
-        let op = extract_file_operation(Some("a/src/lib.rs"), None).unwrap();
+        let op = extract_file_op_unidiff(Some("a/src/lib.rs"), None).unwrap();
         assert_eq!(
             op,
             FileOperation::Modify {
@@ -280,7 +281,7 @@ mod extract_file_operation {
 
     #[test]
     fn missing_original_uses_modified() {
-        let op = extract_file_operation(None, Some("b/src/lib.rs")).unwrap();
+        let op = extract_file_op_unidiff(None, Some("b/src/lib.rs")).unwrap();
         assert_eq!(
             op,
             FileOperation::Modify {
@@ -292,13 +293,13 @@ mod extract_file_operation {
 
     #[test]
     fn both_dev_null_errors() {
-        let result = extract_file_operation(Some("/dev/null"), Some("/dev/null"));
+        let result = extract_file_op_unidiff(Some("/dev/null"), Some("/dev/null"));
         assert!(result.is_err());
     }
 
     #[test]
     fn missing_both_paths_errors() {
-        let result = extract_file_operation(None, None);
+        let result = extract_file_op_unidiff(None, None);
         assert!(result.is_err());
     }
 }
@@ -307,6 +308,7 @@ mod git_diff_boundary {
     use super::*;
 
     #[test]
+    #[ignore]
     fn diff_git_is_boundary_in_gitdiff_mode() {
         let content = "\
 diff --git a/file1.rs b/file1.rs
@@ -322,13 +324,14 @@ diff --git a/file2.rs b/file2.rs
 -old2
 +new2
 ";
-        let patches = split_patches(content, ParseMode::GitDiff);
+        let patches = split_patches_unidiff(content);
         assert_eq!(patches.len(), 2);
         assert!(Patch::from_str(patches[0]).is_ok());
         assert!(Patch::from_str(patches[1]).is_ok());
     }
 
     #[test]
+    #[ignore]
     fn diff_git_not_boundary_in_unidiff_mode() {
         // In UniDiff mode, `diff --git` is just noise before the real boundary
         let content = "\
@@ -345,7 +348,7 @@ diff --git a/file2.rs b/file2.rs
 -old2
 +new2
 ";
-        let patches = split_patches(content, ParseMode::UniDiff);
+        let patches = split_patches_unidiff(content);
         assert_eq!(patches.len(), 2);
         // Both should parse, the `diff --git` lines are just garbage before `---`
         assert!(Patch::from_str(patches[0]).is_ok());
@@ -353,6 +356,7 @@ diff --git a/file2.rs b/file2.rs
     }
 
     #[test]
+    #[ignore]
     fn git_headers_do_not_split_patch() {
         // Git extended headers between `diff --git` and `---` should not cause split
         let content = "\
@@ -365,12 +369,13 @@ new mode 100755
 -old
 +new
 ";
-        let patches = split_patches(content, ParseMode::GitDiff);
+        let patches = split_patches_unidiff(content);
         assert_eq!(patches.len(), 1);
         assert!(Patch::from_str(patches[0]).is_ok());
     }
 
     #[test]
+    #[ignore]
     fn new_file_mode_header() {
         let content = "\
 diff --git a/new.sh b/new.sh
@@ -380,12 +385,13 @@ new file mode 100755
 @@ -0,0 +1 @@
 +content
 ";
-        let patches = split_patches(content, ParseMode::GitDiff);
+        let patches = split_patches_unidiff(content);
         assert_eq!(patches.len(), 1);
         assert!(Patch::from_str(patches[0]).is_ok());
     }
 
     #[test]
+    #[ignore]
     fn deleted_file_mode_header() {
         let content = "\
 diff --git a/old.sh b/old.sh
@@ -395,12 +401,13 @@ deleted file mode 100755
 @@ -1 +0,0 @@
 -content
 ";
-        let patches = split_patches(content, ParseMode::GitDiff);
+        let patches = split_patches_unidiff(content);
         assert_eq!(patches.len(), 1);
         assert!(Patch::from_str(patches[0]).is_ok());
     }
 
     #[test]
+    #[ignore]
     fn rename_headers() {
         let content = "\
 diff --git a/old.txt b/new.txt
@@ -408,12 +415,13 @@ similarity index 100%
 rename from old.txt
 rename to new.txt
 ";
-        let patches = split_patches(content, ParseMode::GitDiff);
+        let patches = split_patches_unidiff(content);
         assert_eq!(patches.len(), 1);
         // Pure rename has no hunks, but should still be one patch slice
     }
 
     #[test]
+    #[ignore]
     fn index_header_recognized() {
         let content = "\
 diff --git a/file.rs b/file.rs
@@ -424,12 +432,13 @@ index 1234567..89abcdef 100644
 -old
 +new
 ";
-        let patches = split_patches(content, ParseMode::GitDiff);
+        let patches = split_patches_unidiff(content);
         assert_eq!(patches.len(), 1);
         assert!(Patch::from_str(patches[0]).is_ok());
     }
 
     #[test]
+    #[ignore]
     fn commit_message_with_diff_git_text_inline() {
         // Only the real "diff --git" at line start is detected
         let content = "\
@@ -449,12 +458,13 @@ diff --git a/file.rs b/file.rs
  real
 +change
 ";
-        let patches = split_patches(content, ParseMode::GitDiff);
+        let patches = split_patches_unidiff(content);
         assert_eq!(patches.len(), 1);
         assert!(Patch::from_str(patches[0]).is_ok());
     }
 
     #[test]
+    #[ignore]
     fn commit_message_with_diff_git_at_line_start() {
         // "diff --git" in commit message is ignored because we strip the email preamble.
         // This is an observed git behavior. See `strip_email_preamble`.
@@ -482,6 +492,7 @@ diff --git a/file.rs b/file.rs
     }
 
     #[test]
+    #[ignore]
     fn multiple_separator_and_diff_git_in_commit_message() {
         // Git uses the first `---` as separator,
         // so the fake ones are included in patch.
@@ -505,7 +516,7 @@ diff --git a/real.rs b/real.rs
  real
 +change
 ";
-        let patches = split_patches(content, ParseMode::GitDiff);
+        let patches = split_patches_unidiff(content);
         // First `---` is used as separator,
         // so both fake and real `diff --git` are detected as patches.
         assert_eq!(patches.len(), 2);
@@ -514,6 +525,7 @@ diff --git a/real.rs b/real.rs
     }
 
     #[test]
+    #[ignore]
     fn multiple_patches_with_various_headers() {
         let content = "\
 diff --git a/file1.rs b/file1.rs
@@ -536,7 +548,7 @@ deleted file mode 100644
 @@ -1 +0,0 @@
 -deleted
 ";
-        let patches = split_patches(content, ParseMode::GitDiff);
+        let patches = split_patches_unidiff(content);
         assert_eq!(patches.len(), 3);
         assert!(Patch::from_str(patches[0]).is_ok());
         assert!(Patch::from_str(patches[1]).is_ok());

--- a/src/patchset/tests.rs
+++ b/src/patchset/tests.rs
@@ -2,7 +2,9 @@
 
 use super::parse::extract_file_op_unidiff;
 use super::parse::split_patches_unidiff;
-use super::{FileOperation, ParseMode, PatchSet};
+use super::FileOperation;
+use super::ParseMode;
+use super::PatchSet;
 use crate::Patch;
 
 mod file_operation {
@@ -226,6 +228,30 @@ No patches here
         assert!(Patch::from_str(patches[1]).is_ok());
         assert!(Patch::from_str(patches[2]).is_ok());
     }
+
+    #[test]
+    fn diff_git_not_boundary_in_unidiff_mode() {
+        // In UniDiff mode, `diff --git` is just noise before the real `---` boundary
+        let content = "\
+diff --git a/file1.rs b/file1.rs
+--- a/file1.rs
++++ b/file1.rs
+@@ -1 +1 @@
+-old1
++new1
+diff --git a/file2.rs b/file2.rs
+--- a/file2.rs
++++ b/file2.rs
+@@ -1 +1 @@
+-old2
++new2
+";
+        let patches = split_patches_unidiff(content);
+        assert_eq!(patches.len(), 2);
+        // Both should parse, the `diff --git` lines are just garbage before `---`
+        assert!(Patch::from_str(patches[0]).is_ok());
+        assert!(Patch::from_str(patches[1]).is_ok());
+    }
 }
 
 mod extract_file_op_unidiff {
@@ -304,12 +330,11 @@ mod extract_file_op_unidiff {
     }
 }
 
-mod git_diff_boundary {
+mod patchset_gitdiff {
     use super::*;
 
     #[test]
-    #[ignore]
-    fn diff_git_is_boundary_in_gitdiff_mode() {
+    fn multi_file_patch() {
         let content = "\
 diff --git a/file1.rs b/file1.rs
 --- a/file1.rs
@@ -324,41 +349,30 @@ diff --git a/file2.rs b/file2.rs
 -old2
 +new2
 ";
-        let patches = split_patches_unidiff(content);
-        assert_eq!(patches.len(), 2);
-        assert!(Patch::from_str(patches[0]).is_ok());
-        assert!(Patch::from_str(patches[1]).is_ok());
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 2);
+
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Modify {
+                original: "a/file1.rs".to_owned(),
+                modified: "b/file1.rs".to_owned(),
+            }
+        );
+        assert_eq!(patchset.patches()[0].patch().hunks().len(), 1);
+
+        assert_eq!(
+            patchset.patches()[1].operation(),
+            &FileOperation::Modify {
+                original: "a/file2.rs".to_owned(),
+                modified: "b/file2.rs".to_owned(),
+            }
+        );
+        assert_eq!(patchset.patches()[1].patch().hunks().len(), 1);
     }
 
     #[test]
-    #[ignore]
-    fn diff_git_not_boundary_in_unidiff_mode() {
-        // In UniDiff mode, `diff --git` is just noise before the real boundary
-        let content = "\
-diff --git a/file1.rs b/file1.rs
---- a/file1.rs
-+++ b/file1.rs
-@@ -1 +1 @@
--old1
-+new1
-diff --git a/file2.rs b/file2.rs
---- a/file2.rs
-+++ b/file2.rs
-@@ -1 +1 @@
--old2
-+new2
-";
-        let patches = split_patches_unidiff(content);
-        assert_eq!(patches.len(), 2);
-        // Both should parse, the `diff --git` lines are just garbage before `---`
-        assert!(Patch::from_str(patches[0]).is_ok());
-        assert!(Patch::from_str(patches[1]).is_ok());
-    }
-
-    #[test]
-    #[ignore]
-    fn git_headers_do_not_split_patch() {
-        // Git extended headers between `diff --git` and `---` should not cause split
+    fn modify_with_mode_change() {
         let content = "\
 diff --git a/file.rs b/file.rs
 old mode 100644
@@ -369,14 +383,21 @@ new mode 100755
 -old
 +new
 ";
-        let patches = split_patches_unidiff(content);
-        assert_eq!(patches.len(), 1);
-        assert!(Patch::from_str(patches[0]).is_ok());
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Modify {
+                original: "a/file.rs".to_owned(),
+                modified: "b/file.rs".to_owned(),
+            }
+        );
+        assert_eq!(patchset.patches()[0].patch().hunks().len(), 1);
     }
 
     #[test]
-    #[ignore]
-    fn new_file_mode_header() {
+    fn create_file() {
         let content = "\
 diff --git a/new.sh b/new.sh
 new file mode 100755
@@ -385,14 +406,18 @@ new file mode 100755
 @@ -0,0 +1 @@
 +content
 ";
-        let patches = split_patches_unidiff(content);
-        assert_eq!(patches.len(), 1);
-        assert!(Patch::from_str(patches[0]).is_ok());
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Create("b/new.sh".to_owned())
+        );
+        assert_eq!(patchset.patches()[0].patch().hunks().len(), 1);
     }
 
     #[test]
-    #[ignore]
-    fn deleted_file_mode_header() {
+    fn delete_file() {
         let content = "\
 diff --git a/old.sh b/old.sh
 deleted file mode 100755
@@ -401,46 +426,117 @@ deleted file mode 100755
 @@ -1 +0,0 @@
 -content
 ";
-        let patches = split_patches_unidiff(content);
-        assert_eq!(patches.len(), 1);
-        assert!(Patch::from_str(patches[0]).is_ok());
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Delete("a/old.sh".to_owned())
+        );
+        assert_eq!(patchset.patches()[0].patch().hunks().len(), 1);
     }
 
     #[test]
-    #[ignore]
-    fn rename_headers() {
+    fn pure_rename() {
         let content = "\
 diff --git a/old.txt b/new.txt
 similarity index 100%
 rename from old.txt
 rename to new.txt
 ";
-        let patches = split_patches_unidiff(content);
-        assert_eq!(patches.len(), 1);
-        // Pure rename has no hunks, but should still be one patch slice
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Rename {
+                from: "old.txt".to_owned(),
+                to: "new.txt".to_owned(),
+            }
+        );
+        // Pure rename has no hunks
+        assert!(patchset.patches()[0].patch().hunks().is_empty());
     }
 
     #[test]
-    #[ignore]
-    fn index_header_recognized() {
+    fn pure_copy() {
         let content = "\
-diff --git a/file.rs b/file.rs
-index 1234567..89abcdef 100644
---- a/file.rs
-+++ b/file.rs
-@@ -1 +1 @@
--old
-+new
+diff --git a/original.txt b/copy.txt
+similarity index 100%
+copy from original.txt
+copy to copy.txt
 ";
-        let patches = split_patches_unidiff(content);
-        assert_eq!(patches.len(), 1);
-        assert!(Patch::from_str(patches[0]).is_ok());
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Copy {
+                from: "original.txt".to_owned(),
+                to: "copy.txt".to_owned(),
+            }
+        );
+        // Pure copy has no hunks
+        assert!(patchset.patches()[0].patch().hunks().is_empty());
     }
 
     #[test]
-    #[ignore]
-    fn commit_message_with_diff_git_text_inline() {
-        // Only the real "diff --git" at line start is detected
+    fn rename_with_changes() {
+        let content = "\
+diff --git a/old.txt b/new.txt
+similarity index 90%
+rename from old.txt
+rename to new.txt
+--- a/old.txt
++++ b/new.txt
+@@ -1 +1 @@
+-old content
++new content
+";
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Rename {
+                from: "old.txt".to_owned(),
+                to: "new.txt".to_owned(),
+            }
+        );
+        // Rename with changes has hunks
+        assert_eq!(patchset.patches()[0].patch().hunks().len(), 1);
+    }
+
+    #[test]
+    fn copy_with_changes() {
+        let content = "\
+diff --git a/original.txt b/copy.txt
+similarity index 80%
+copy from original.txt
+copy to copy.txt
+--- a/original.txt
++++ b/copy.txt
+@@ -1,2 +1,3 @@
+ line1
+ line2
++line3
+";
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Copy {
+                from: "original.txt".to_owned(),
+                to: "copy.txt".to_owned(),
+            }
+        );
+        // Copy with changes has hunks
+        assert_eq!(patchset.patches()[0].patch().hunks().len(), 1);
+    }
+
+    #[test]
+    fn format_patch_with_preamble() {
         let content = "\
 From abc123 Mon Sep 17 00:00:00 2001
 From: Test <test@test.com>
@@ -458,16 +554,66 @@ diff --git a/file.rs b/file.rs
  real
 +change
 ";
-        let patches = split_patches_unidiff(content);
-        assert_eq!(patches.len(), 1);
-        assert!(Patch::from_str(patches[0]).is_ok());
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Modify {
+                original: "a/file.rs".to_owned(),
+                modified: "b/file.rs".to_owned(),
+            }
+        );
     }
 
     #[test]
-    #[ignore]
+    fn mode_only_change_not_supported() {
+        let content = "\
+diff --git a/script.sh b/script.sh
+old mode 100644
+new mode 100755
+";
+        let result = PatchSet::parse(content, ParseMode::GitDiff);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn binary_file_not_supported() {
+        let content = "\
+diff --git a/image.png b/image.png
+index 1234567..89abcdef 100644
+Binary files a/image.png and b/image.png differ
+";
+        let result = PatchSet::parse(content, ParseMode::GitDiff);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn index_header_recognized() {
+        let content = "\
+diff --git a/file.rs b/file.rs
+index 1234567..89abcdef 100644
+--- a/file.rs
++++ b/file.rs
+@@ -1 +1 @@
+-old
++new
+";
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Modify {
+                original: "a/file.rs".to_owned(),
+                modified: "b/file.rs".to_owned(),
+            }
+        );
+    }
+
+    #[test]
     fn commit_message_with_diff_git_at_line_start() {
-        // "diff --git" in commit message is ignored because we strip the email preamble.
-        // This is an observed git behavior. See `strip_email_preamble`.
+        // "diff --git" in commit message is stripped by strip_email_preamble.
+        // This is observed git behavior.
         let content = "\
 From abc123 Mon Sep 17 00:00:00 2001
 Subject: [PATCH] test
@@ -492,12 +638,10 @@ diff --git a/file.rs b/file.rs
     }
 
     #[test]
-    #[ignore]
-    fn multiple_separator_and_diff_git_in_commit_message() {
-        // Git uses the first `---` as separator,
-        // so the fake ones are included in patch.
-        //
-        // This is an observed git behavior. See `strip_email_preamble`.
+    fn multiple_separator_in_commit_message() {
+        // Git uses the first `\n---\n` as separator (observed git mailinfo behavior).
+        // The fake `diff --git` after first separator becomes a real patch boundary,
+        // but lacks `---`/`+++` headers, causing a parse error.
         let content = "\
 From abc123 Mon Sep 17 00:00:00 2001
 Subject: [PATCH] test
@@ -516,17 +660,14 @@ diff --git a/real.rs b/real.rs
  real
 +change
 ";
-        let patches = split_patches_unidiff(content);
-        // First `---` is used as separator,
-        // so both fake and real `diff --git` are detected as patches.
-        assert_eq!(patches.len(), 2);
-        assert!(patches[0].contains("diff --git a/fake"));
-        assert!(patches[1].contains("diff --git a/real.rs"));
+        // First `---` strips preamble, exposing fake `diff --git` as patch boundary.
+        // The fake patch has no `---`/`+++` headers, so parsing fails.
+        let result = PatchSet::parse(content, ParseMode::GitDiff);
+        assert!(result.is_err());
     }
 
     #[test]
-    #[ignore]
-    fn multiple_patches_with_various_headers() {
+    fn multiple_patches_with_various_operations() {
         let content = "\
 diff --git a/file1.rs b/file1.rs
 index 1111111..2222222 100644
@@ -548,11 +689,31 @@ deleted file mode 100644
 @@ -1 +0,0 @@
 -deleted
 ";
-        let patches = split_patches_unidiff(content);
-        assert_eq!(patches.len(), 3);
-        assert!(Patch::from_str(patches[0]).is_ok());
-        assert!(Patch::from_str(patches[1]).is_ok());
-        assert!(Patch::from_str(patches[2]).is_ok());
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 3);
+        assert!(patchset.patches()[0].operation().is_modify());
+        assert!(patchset.patches()[1].operation().is_create());
+        assert!(patchset.patches()[2].operation().is_delete());
+    }
+
+    #[test]
+    fn rename_with_spaces_in_path() {
+        let content = "\
+diff --git a/path with spaces/old file.txt b/path with spaces/new file.txt
+similarity index 100%
+rename from path with spaces/old file.txt
+rename to path with spaces/new file.txt
+";
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Rename {
+                from: "path with spaces/old file.txt".to_owned(),
+                to: "path with spaces/new file.txt".to_owned(),
+            }
+        );
     }
 }
 

--- a/tests/replay.rs
+++ b/tests/replay.rs
@@ -1,5 +1,8 @@
 //! Validate PatchSet parsing and application by replaying a git repository's history.
 //!
+//! Note: Git extended header paths (rename/copy) don't have a/b prefixes,
+//! while ---/+++ paths do. This test handles both cases appropriately.
+//!
 //! ## Usage
 //!
 //! ```console
@@ -28,6 +31,18 @@ use std::thread;
 use diffy::patchset::FileOperation;
 use diffy::patchset::ParseMode;
 use diffy::patchset::PatchSet;
+
+/// Strip the first `n` path components from a path.
+fn strip_path_prefix(path: &str, n: usize) -> String {
+    let mut remaining = path;
+    for _ in 0..n {
+        match remaining.split_once('/') {
+            Some((_first, rest)) => remaining = rest,
+            None => return remaining.to_owned(),
+        }
+    }
+    remaining.to_owned()
+}
 
 /// Result of processing a single commit pair.
 struct CommitResult {
@@ -233,29 +248,38 @@ fn process_commit(
     }
 
     for file_patch in patchset.iter() {
-        let operation = file_patch.operation().strip_prefix(1);
+        // Paths from ---/+++ headers have a/b prefixes that need stripping.
+        // Paths from git extended headers (rename/copy) are already clean.
+        let operation = file_patch.operation();
 
-        let (base_content, expected_content, desc) = match &operation {
+        let (base_content, expected_content, desc) = match operation {
             FileOperation::Create(path) => {
-                let Some(expected) = file_at_commit(repo, child, path) else {
+                // Create paths come from +++ header, strip a/b prefix
+                let path = strip_path_prefix(path, 1);
+                let Some(expected) = file_at_commit(repo, child, &path) else {
                     skipped += 1;
                     continue;
                 };
                 (String::new(), expected, format!("create {path}"))
             }
             FileOperation::Delete(path) => {
-                let Some(base) = file_at_commit(repo, parent, path) else {
+                // Delete paths come from --- header, strip a/b prefix
+                let path = strip_path_prefix(path, 1);
+                let Some(base) = file_at_commit(repo, parent, &path) else {
                     skipped += 1;
                     continue;
                 };
                 (base, String::new(), format!("delete {path}"))
             }
             FileOperation::Modify { original, modified } => {
-                let Some(base) = file_at_commit(repo, parent, original) else {
+                // Modify paths come from ---/+++ headers, strip a/b prefix
+                let original = strip_path_prefix(original, 1);
+                let modified = strip_path_prefix(modified, 1);
+                let Some(base) = file_at_commit(repo, parent, &original) else {
                     skipped += 1;
                     continue;
                 };
-                let Some(expected) = file_at_commit(repo, child, modified) else {
+                let Some(expected) = file_at_commit(repo, child, &modified) else {
                     skipped += 1;
                     continue;
                 };
@@ -266,6 +290,7 @@ fn process_commit(
                 };
                 (base, expected, desc)
             }
+            // Rename/Copy paths come from git headers WITHOUT a/b prefix
             FileOperation::Rename { from, to } => {
                 let Some(base) = file_at_commit(repo, parent, from) else {
                     skipped += 1;


### PR DESCRIPTION
Parse Git extended header in single pass.

See <https://git-scm.com/docs/diff-format> for more about the format

See also code comments for assumption and observed behavior.