### PR TITLE
feat(patchset): mode-only and empty file patches support

### DIFF
--- a/src/patch/mod.rs
+++ b/src/patch/mod.rs
@@ -8,6 +8,9 @@ pub use parse::ParsePatchError;
 
 use std::{borrow::Cow, fmt, ops};
 
+use crate::utils::ESCAPED_CHARS;
+use crate::utils::ESCAPED_CHARS_BYTES;
+
 const NO_NEWLINE_AT_EOF: &str = "\\ No newline at end of file";
 
 /// Representation of all the differences between two files
@@ -144,10 +147,6 @@ where
 
 #[derive(PartialEq, Eq)]
 struct Filename<'a, T: ToOwned + ?Sized>(Cow<'a, T>);
-
-const ESCAPED_CHARS: &[char] = &['\n', '\t', '\0', '\r', '\"', '\\'];
-#[allow(clippy::byte_char_slices)]
-const ESCAPED_CHARS_BYTES: &[u8] = &[b'\n', b'\t', b'\0', b'\r', b'\"', b'\\'];
 
 impl Filename<'_, str> {
     fn needs_to_be_escaped(&self) -> bool {

--- a/src/patch/parse.rs
+++ b/src/patch/parse.rs
@@ -1,9 +1,9 @@
 //! Parse a Patch
 
-use super::{Hunk, HunkRange, Line, ESCAPED_CHARS_BYTES, NO_NEWLINE_AT_EOF};
+use super::{Hunk, HunkRange, Line, NO_NEWLINE_AT_EOF};
 use crate::{
     patch::Patch,
-    utils::{LineIter, Text},
+    utils::{escaped_filename, LineIter, Text, ESCAPED_CHARS_BYTES},
 };
 use std::{borrow::Cow, fmt};
 
@@ -160,35 +160,6 @@ fn unescaped_filename<T: Text + ToOwned + ?Sized>(filename: &T) -> Result<Cow<'_
     }
 
     Ok(bytes.into())
-}
-
-fn escaped_filename<T: Text + ToOwned + ?Sized>(escaped: &T) -> Result<Cow<'_, [u8]>> {
-    let mut filename = Vec::new();
-
-    let mut chars = escaped.as_bytes().iter().copied();
-    while let Some(c) = chars.next() {
-        if c == b'\\' {
-            let ch = match chars
-                .next()
-                .ok_or_else(|| ParsePatchError::new("expected escaped character"))?
-            {
-                b'n' => b'\n',
-                b't' => b'\t',
-                b'0' => b'\0',
-                b'r' => b'\r',
-                b'\"' => b'\"',
-                b'\\' => b'\\',
-                _ => return Err(ParsePatchError::new("invalid escaped character")),
-            };
-            filename.push(ch);
-        } else if ESCAPED_CHARS_BYTES.contains(&c) {
-            return Err(ParsePatchError::new("invalid unescaped character"));
-        } else {
-            filename.push(c);
-        }
-    }
-
-    Ok(filename.into())
 }
 
 fn verify_hunks_in_order<T: ?Sized>(hunks: &[Hunk<'_, T>]) -> bool {

--- a/src/patch/parse.rs
+++ b/src/patch/parse.rs
@@ -3,7 +3,7 @@
 use super::{Hunk, HunkRange, Line, NO_NEWLINE_AT_EOF};
 use crate::{
     patch::Patch,
-    utils::{escaped_filename, LineIter, Text, ESCAPED_CHARS_BYTES},
+    utils::{escaped_filename, LineIter, Text},
 };
 use std::{borrow::Cow, fmt};
 
@@ -139,27 +139,9 @@ fn parse_filename<'a, T: Text + ToOwned + ?Sized>(
         return Err(ParsePatchError::new("filename unterminated"));
     };
 
-    let filename = if let Some(quoted) = is_quoted(filename) {
-        escaped_filename(quoted)?
-    } else {
-        unescaped_filename(filename)?
-    };
+    let filename = escaped_filename(filename)?;
 
     Ok(filename)
-}
-
-fn is_quoted<T: Text + ?Sized>(s: &T) -> Option<&T> {
-    s.strip_prefix("\"").and_then(|s| s.strip_suffix("\""))
-}
-
-fn unescaped_filename<T: Text + ToOwned + ?Sized>(filename: &T) -> Result<Cow<'_, [u8]>> {
-    let bytes = filename.as_bytes();
-
-    if bytes.iter().any(|b| ESCAPED_CHARS_BYTES.contains(b)) {
-        return Err(ParsePatchError::new("invalid char in unquoted filename"));
-    }
-
-    Ok(bytes.into())
 }
 
 fn verify_hunks_in_order<T: ?Sized>(hunks: &[Hunk<'_, T>]) -> bool {

--- a/src/patchset/mod.rs
+++ b/src/patchset/mod.rs
@@ -127,6 +127,33 @@ impl<'a, 'b, T: ToOwned + ?Sized> IntoIterator for &'b PatchSet<'a, T> {
     }
 }
 
+/// File mode extracted from git extended headers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileMode {
+    /// `100644` regular file
+    Regular,
+    /// `100755` executable file
+    Executable,
+    /// `120000` symlink
+    Symlink,
+    /// `160000` gitlink (submodule)
+    Gitlink,
+}
+
+impl std::str::FromStr for FileMode {
+    type Err = ParsePatchError;
+
+    fn from_str(mode: &str) -> Result<Self, Self::Err> {
+        match mode {
+            "100644" => Ok(Self::Regular),
+            "100755" => Ok(Self::Executable),
+            "120000" => Ok(Self::Symlink),
+            "160000" => Ok(Self::Gitlink),
+            _ => Err(ParsePatchError::new(format!("invalid file mode: {mode}"))),
+        }
+    }
+}
+
 /// A single file's patch with operation metadata.
 ///
 /// This combines a [`Patch`] with a [`FileOperation`]

--- a/src/patchset/mod.rs
+++ b/src/patchset/mod.rs
@@ -84,7 +84,7 @@ impl<'a> PatchSet<'a, str> {
 }
 
 impl<'a, T: ToOwned + ?Sized> PatchSet<'a, T> {
-    pub(crate) fn new(patches: Vec<FilePatch<'a, T>>) -> Self {
+    fn new(patches: Vec<FilePatch<'a, T>>) -> Self {
         Self { patches }
     }
 
@@ -152,7 +152,7 @@ where
 }
 
 impl<'a, T: ToOwned + ?Sized> FilePatch<'a, T> {
-    pub(crate) fn new(operation: FileOperation, patch: Patch<'a, T>) -> Self {
+    fn new(operation: FileOperation, patch: Patch<'a, T>) -> Self {
         Self { operation, patch }
     }
 

--- a/src/patchset/mod.rs
+++ b/src/patchset/mod.rs
@@ -163,6 +163,8 @@ impl std::str::FromStr for FileMode {
 pub struct FilePatch<'a, T: ToOwned + ?Sized> {
     operation: FileOperation,
     patch: Patch<'a, T>,
+    old_mode: Option<FileMode>,
+    new_mode: Option<FileMode>,
 }
 
 impl<T: ?Sized, O> std::fmt::Debug for FilePatch<'_, T>
@@ -174,13 +176,25 @@ where
         f.debug_struct("FilePatch")
             .field("operation", &self.operation)
             .field("patch", &self.patch)
+            .field("old_mode", &self.old_mode)
+            .field("new_mode", &self.new_mode)
             .finish()
     }
 }
 
 impl<'a, T: ToOwned + ?Sized> FilePatch<'a, T> {
-    fn new(operation: FileOperation, patch: Patch<'a, T>) -> Self {
-        Self { operation, patch }
+    fn new(
+        operation: FileOperation,
+        patch: Patch<'a, T>,
+        old_mode: Option<FileMode>,
+        new_mode: Option<FileMode>,
+    ) -> Self {
+        Self {
+            operation,
+            patch,
+            old_mode,
+            new_mode,
+        }
     }
 
     /// Returns the file operation for this patch.
@@ -196,6 +210,16 @@ impl<'a, T: ToOwned + ?Sized> FilePatch<'a, T> {
     /// Consumes the [`FilePatch`] and returns the underlying [`Patch`].
     pub fn into_patch(self) -> Patch<'a, T> {
         self.patch
+    }
+
+    /// Returns the old file mode, if present.
+    pub fn old_mode(&self) -> Option<&FileMode> {
+        self.old_mode.as_ref()
+    }
+
+    /// Returns the new file mode, if present.
+    pub fn new_mode(&self) -> Option<&FileMode> {
+        self.new_mode.as_ref()
     }
 }
 

--- a/src/patchset/parse.rs
+++ b/src/patchset/parse.rs
@@ -196,6 +196,11 @@ fn is_unidiff_boundary(prev: Option<&str>, line: &str, next: Option<&str>) -> bo
 ///
 /// [`git format-patch`]: https://git-scm.com/docs/git-format-patch
 fn strip_email_preamble(input: &str) -> &str {
+    // only strip preamble for mbox-formatted input
+    if !input.starts_with("From ") {
+        return input;
+    }
+
     match input.find(EMAIL_PREAMBLE_SEPARATOR) {
         Some(pos) => &input[pos + EMAIL_PREAMBLE_SEPARATOR.len()..],
         None => input,

--- a/src/patchset/parse.rs
+++ b/src/patchset/parse.rs
@@ -1,6 +1,9 @@
 //! Parse multiple file patches from a unified diff.
 
-use super::{FileOperation, FilePatch, ParseMode, PatchSet};
+use std::borrow::Cow;
+
+use super::{FileMode, FileOperation, FilePatch, ParseMode, PatchSet};
+use crate::utils::escaped_filename;
 use crate::{ParsePatchError, Patch};
 
 /// Prefix for the original file path (e.g., `--- a/file.rs`).
@@ -35,8 +38,10 @@ fn parse_gitdiff(input: &str) -> Result<PatchSet<'_, str>, ParsePatchError> {
     for raw in split_patches_gitdiff(input) {
         let header = GitHeader::parse(raw.header);
         let patch = Patch::from_str(raw.patch)?;
-        let operation = extract_file_op_gitdiff(header.as_ref(), &patch)?;
-        patches.push(FilePatch::new(operation, patch));
+        let operation = extract_file_op_gitdiff(&header, &patch)?;
+        let old_mode = header.old_mode.map(str::parse::<FileMode>).transpose()?;
+        let new_mode = header.new_mode.map(str::parse::<FileMode>).transpose()?;
+        patches.push(FilePatch::new(operation, patch, old_mode, new_mode));
     }
 
     Ok(PatchSet::new(patches))
@@ -49,7 +54,7 @@ fn parse_unidiff(input: &str) -> Result<PatchSet<'_, str>, ParsePatchError> {
     for patch_str in patch_strs {
         let patch = Patch::from_str(patch_str)?;
         let operation = extract_file_op_unidiff(patch.original(), patch.modified())?;
-        patches.push(FilePatch::new(operation, patch));
+        patches.push(FilePatch::new(operation, patch, None, None));
     }
 
     Ok(PatchSet::new(patches))
@@ -274,29 +279,222 @@ pub fn extract_file_op_unidiff(
     }
 }
 
-/// Determines the file operation using git headers (if available) and patch paths.
+/// Determines the file operation using git headers and patch paths.
 fn extract_file_op_gitdiff(
-    header: Option<&GitHeader<'_>>,
+    header: &GitHeader<'_>,
     patch: &Patch<'_, str>,
 ) -> Result<FileOperation, ParsePatchError> {
     // Git headers are authoritative for rename/copy
-    if let Some(h) = header {
-        if let (Some(from), Some(to)) = (h.rename_from, h.rename_to) {
-            return Ok(FileOperation::Rename {
-                from: from.to_owned(),
-                to: to.to_owned(),
-            });
+    if let (Some(from), Some(to)) = (header.rename_from, header.rename_to) {
+        return Ok(FileOperation::Rename {
+            from: from.to_owned(),
+            to: to.to_owned(),
+        });
+    }
+    if let (Some(from), Some(to)) = (header.copy_from, header.copy_to) {
+        return Ok(FileOperation::Copy {
+            from: from.to_owned(),
+            to: to.to_owned(),
+        });
+    }
+
+    // Try ---/+++ paths first
+    if patch.original().is_some() || patch.modified().is_some() {
+        return extract_file_op_unidiff(patch.original(), patch.modified());
+    }
+
+    // Fall back to `diff --git <old> <new>` for mode-only and empty file changes.
+    let Some((original, modified)) = header.diff_git_line.and_then(parse_diff_git_path) else {
+        return Err(ParsePatchError::new("unable to parse `diff --git` path"));
+    };
+
+    let op = if header.new_file_mode.is_some() {
+        FileOperation::Create(modified.into_owned())
+    } else if header.deleted_file_mode.is_some() {
+        FileOperation::Delete(original.into_owned())
+    } else {
+        FileOperation::Modify {
+            original: original.into_owned(),
+            modified: modified.into_owned(),
         }
-        if let (Some(from), Some(to)) = (h.copy_from, h.copy_to) {
-            return Ok(FileOperation::Copy {
-                from: from.to_owned(),
-                to: to.to_owned(),
-            });
+    };
+
+    Ok(op)
+}
+
+/// Extracts both old and new paths from `diff --git` line content.
+///
+/// ## Assumption #1: old and new paths are the same
+///
+/// This extraction has one strong assumption:
+/// Beside their prefixes, old and new paths are the same.
+///
+/// From [git-diff format documentation]:
+///
+/// > The `a/` and `b/` filenames are the same unless rename/copy is involved.
+/// > Especially, even for a creation or a deletion, `/dev/null` is not used
+/// > in place of the `a/` or `b/` filenames.
+/// >
+/// > When a rename/copy is involved, file1 and file2 show the name of the
+/// > source file of the rename/copy and the name of the file that the
+/// > rename/copy produces, respectively.
+///
+/// Since rename/copy operations use `rename from/to` and `copy from/to` headers
+/// we have handled earlier in [`extract_file_op_gitdiff`],
+/// (which have no `a/`/`b/` prefix per git spec),
+///
+/// this extraction is only used
+/// * when unified diff headers (`---`/`+++`) are absent
+/// * Only for in mode-only and empty file cases
+///
+/// [git-diff format documentation]: https://git-scm.com/docs/diff-format
+///
+/// ## Assumption #2: the longest common path suffix is the shared path
+///
+/// When custom prefixes contain spaces,
+/// multiple splits may produce valid path suffixes.
+///
+/// Example: `src/foo.rs src/foo.rs src/foo.rs src/foo.rs`
+///
+/// Three splits all produce valid path suffixes (contain `/`):
+///
+/// * Position 10
+///   * old path: `src/foo.rs`
+///   * new path: `src/foo.rs src/foo.rs src/foo.rs`
+///   * common suffix: `foo.rs`
+/// * Position 21
+///   * old path: `src/foo.rs src/foo.rs`
+///   * new path: `src/foo.rs src/foo.rs`
+///   * common suffix: `foo.rs src/foo.rs`
+/// * Position 32
+///   * old path: `src/foo.rs src/foo.rs src/foo.rs`
+///   * new path: `src/foo.rs`
+///   * common suffix: `foo.rs`
+///
+/// We observed that `git apply` would pick position 21,
+/// which has the longest path suffix,
+/// hence this heuristic.
+///
+/// ## Supported formats
+///
+/// * `a/<path> b/<path>` (defualt prefix)
+/// * `<path> <path>` (`git diff --no-prefix`)
+/// * `<src-prefix><path> <dst-prefix><path>` (custom prefix)
+/// * `"<prefix><path>" "<prefix><path>"` (quoted, with escapes)
+/// * Mixed quoted/unquoted
+fn parse_diff_git_path(line: &str) -> Option<(Cow<'_, str>, Cow<'_, str>)> {
+    if line.starts_with('"') || line.ends_with('"') {
+        parse_quoted_diff_git_path(line)
+    } else {
+        parse_unquoted_diff_git_path(line)
+    }
+}
+
+/// See [`parse_diff_git_path`].
+fn parse_unquoted_diff_git_path(line: &str) -> Option<(Cow<'_, str>, Cow<'_, str>)> {
+    let mut best_match = None;
+    let mut longest_path = "";
+
+    for (i, _) in line.match_indices(' ') {
+        let left = &line[..i];
+        let right = &line[i + 1..];
+
+        if left.is_empty() || right.is_empty() {
+            continue;
+        }
+
+        // Select split with longest common path suffix (matches Git behavior)
+        if let Some(path) = longest_common_path_suffix(left, right) {
+            if path.len() > longest_path.len() {
+                longest_path = path;
+                best_match = Some((left, right));
+            }
         }
     }
 
-    // Fall back to ---/+++ paths
-    extract_file_op_unidiff(patch.original(), patch.modified())
+    best_match.map(|(l, r)| (Cow::Borrowed(l), Cow::Borrowed(r)))
+}
+
+/// See [`parse_diff_git_path`].
+fn parse_quoted_diff_git_path(line: &str) -> Option<(Cow<'_, str>, Cow<'_, str>)> {
+    let (left_raw, right_raw) = if line.starts_with('"') {
+        // First token is quoted.
+        let bytes = line.as_bytes();
+        let mut i = 1; // skip starting `"`
+        let end = loop {
+            // get may return None for malformed input, like missing closing quote
+            // TODO: we might want to have dedicated error kind
+            match bytes.get(i)? {
+                b'"' => break i + 1,
+                b'\\' => i += 2,
+                _ => i += 1,
+            }
+        };
+        let (first, rest) = line.split_at(end);
+        let rest = rest.strip_prefix(' ')?;
+        (first, rest)
+    } else if let Some(pos) = line.find(" \"") {
+        // First token is unquoted. The second must be quoted
+        let first = &line[..pos];
+        let rest = &line[pos + 1..];
+        (first, rest)
+    } else {
+        // Both unquoted. Shouldn't reach here since we've checked for `"` first
+        unreachable!("must be quoted");
+    };
+
+    let left = escaped_filename(left_raw).ok().and_then(|cow| match cow {
+        Cow::Borrowed(b) => std::str::from_utf8(b).ok().map(Cow::Borrowed),
+        Cow::Owned(v) => String::from_utf8(v).ok().map(Cow::Owned),
+    })?;
+    let right = escaped_filename(right_raw).ok().and_then(|cow| match cow {
+        Cow::Borrowed(b) => std::str::from_utf8(b).ok().map(Cow::Borrowed),
+        Cow::Owned(v) => String::from_utf8(v).ok().map(Cow::Owned),
+    })?;
+
+    // Verify both sides have same path.
+    longest_common_path_suffix(&left, &right)?;
+
+    Some((left, right))
+}
+
+/// Extracts the longest common path suffix that starts at a path component boundary.
+///
+/// `None` if no valid common path exists.
+///
+/// Path component boundary means:
+///
+/// * At '/' character (e.g., "foo/bar.rs" vs "fooo/bar.rs" stops at '/' -> "bar.rs")
+/// * Or the entire string is identical
+fn longest_common_path_suffix<'a>(a: &'a str, b: &'a str) -> Option<&'a str> {
+    if a.is_empty() || b.is_empty() {
+        return None;
+    }
+
+    let suffix_len = a
+        .as_bytes()
+        .iter()
+        .rev()
+        .zip(b.as_bytes().iter().rev())
+        .take_while(|(x, y)| x == y)
+        .count();
+
+    if suffix_len == 0 {
+        return None;
+    }
+
+    // Identical strings: suffix covers entire string
+    if suffix_len == a.len() && a.len() == b.len() {
+        return Some(a);
+    }
+
+    // Find first '/' in suffix and return path after it
+    let suffix_start_idx = a.len() - suffix_len;
+    let suffix = &a[suffix_start_idx..];
+    suffix
+        .split_once('/')
+        .map(|(_, path)| path)
+        .filter(|p| !p.is_empty())
 }
 
 /// A single file's patch split into header and unified diff sections.
@@ -344,37 +542,56 @@ impl<'a> GitDiff<'a> {
 /// See [git-diff format documentation](https://git-scm.com/docs/diff-format).
 #[derive(Debug, Default, PartialEq, Eq)]
 struct GitHeader<'a> {
+    /// Raw content after "diff --git " prefix.
+    ///
+    /// Only parsed in fallback when `---`/`+++` is absent (mode-only, binary, empty file).
+    diff_git_line: Option<&'a str>,
+    /// Source path from `rename from <path>`.
     rename_from: Option<&'a str>,
+    /// Destination path from `rename to <path>`.
     rename_to: Option<&'a str>,
+    /// Source path from `copy from <path>`.
     copy_from: Option<&'a str>,
+    /// Destination path from `copy to <path>`.
     copy_to: Option<&'a str>,
+    /// File mode from `old mode <mode>`.
+    old_mode: Option<&'a str>,
+    /// File mode from `new mode <mode>`.
+    new_mode: Option<&'a str>,
+    /// File mode from `new file mode <mode>`.
+    new_file_mode: Option<&'a str>,
+    /// File mode from `deleted file mode <mode>`.
+    deleted_file_mode: Option<&'a str>,
 }
 
 impl<'a> GitHeader<'a> {
     /// Parses git extended header metadata from a pre-split header string.
-    ///
-    /// Returns `None` if no recognizable git headers are found.
-    fn parse(header_str: &'a str) -> Option<Self> {
+    fn parse(header_str: &'a str) -> Self {
         let mut header = GitHeader::default();
-        let mut found_any = false;
 
         for line in header_str.lines() {
-            if let Some(path) = line.strip_prefix("rename from ") {
+            if let Some(rest) = line.strip_prefix("diff --git ") {
+                header.diff_git_line = Some(rest);
+            } else if let Some(path) = line.strip_prefix("rename from ") {
                 header.rename_from = Some(path);
-                found_any = true;
             } else if let Some(path) = line.strip_prefix("rename to ") {
                 header.rename_to = Some(path);
-                found_any = true;
             } else if let Some(path) = line.strip_prefix("copy from ") {
                 header.copy_from = Some(path);
-                found_any = true;
             } else if let Some(path) = line.strip_prefix("copy to ") {
                 header.copy_to = Some(path);
-                found_any = true;
+            } else if let Some(mode) = line.strip_prefix("old mode ") {
+                header.old_mode = Some(mode);
+            } else if let Some(mode) = line.strip_prefix("new mode ") {
+                header.new_mode = Some(mode);
+            } else if let Some(mode) = line.strip_prefix("new file mode ") {
+                header.new_file_mode = Some(mode);
+            } else if let Some(mode) = line.strip_prefix("deleted file mode ") {
+                header.deleted_file_mode = Some(mode);
             }
-            // TODO: old mode, new mode, similarity index, dissimilarity index, index <hash>..<hash>
+            // Ignored: similarity index, dissimilarity index, index
         }
 
-        found_any.then_some(header)
+        header
     }
 }

--- a/src/patchset/parse.rs
+++ b/src/patchset/parse.rs
@@ -58,7 +58,7 @@ fn parse_unidiff(input: &str) -> Result<PatchSet<'_, str>, ParsePatchError> {
 /// Splits a git diff containing multiple file patches (GitDiff mode).
 ///
 /// Content should be email preamble stripped.
-pub(crate) fn split_patches_gitdiff(content: &str) -> Vec<GitDiff<'_>> {
+fn split_patches_gitdiff(content: &str) -> Vec<GitDiff<'_>> {
     let mut patches = Vec::new();
     let mut patch_start = None::<usize>;
     let mut header_end = None::<usize>; // byte offset where `---` was found
@@ -296,13 +296,13 @@ fn extract_file_op_gitdiff(
 
 /// A single file's patch split into header and unified diff sections.
 #[derive(Debug)]
-pub(crate) struct GitDiff<'a> {
+struct GitDiff<'a> {
     /// Lines between `diff --git` and `---` (extended header).
-    pub header: &'a str,
+    header: &'a str,
     /// The unified diff content (`---`/`+++` and hunks).
     ///
     /// For pure renames/mode-only changes, this is empty.
-    pub patch: &'a str,
+    patch: &'a str,
 }
 
 impl<'a> GitDiff<'a> {
@@ -338,18 +338,18 @@ impl<'a> GitDiff<'a> {
 /// Extracted from lines between `diff --git` and `---` (or end of patch).
 /// See [git-diff format documentation](https://git-scm.com/docs/diff-format).
 #[derive(Debug, Default, PartialEq, Eq)]
-pub(crate) struct GitHeader<'a> {
-    pub(crate) rename_from: Option<&'a str>,
-    pub(crate) rename_to: Option<&'a str>,
-    pub(crate) copy_from: Option<&'a str>,
-    pub(crate) copy_to: Option<&'a str>,
+struct GitHeader<'a> {
+    rename_from: Option<&'a str>,
+    rename_to: Option<&'a str>,
+    copy_from: Option<&'a str>,
+    copy_to: Option<&'a str>,
 }
 
 impl<'a> GitHeader<'a> {
     /// Parses git extended header metadata from a pre-split header string.
     ///
     /// Returns `None` if no recognizable git headers are found.
-    pub(crate) fn parse(header_str: &'a str) -> Option<Self> {
+    fn parse(header_str: &'a str) -> Option<Self> {
         let mut header = GitHeader::default();
         let mut found_any = false;
 

--- a/src/patchset/tests.rs
+++ b/src/patchset/tests.rs
@@ -2,6 +2,7 @@
 
 use super::parse::extract_file_op_unidiff;
 use super::parse::split_patches_unidiff;
+use super::FileMode;
 use super::FileOperation;
 use super::ParseMode;
 use super::PatchSet;
@@ -437,6 +438,40 @@ deleted file mode 100755
     }
 
     #[test]
+    fn empty_file_create() {
+        let content = "\
+diff --git a/empty.txt b/empty.txt
+new file mode 100644
+index 0000000..e69de29
+";
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Create("b/empty.txt".to_owned())
+        );
+        assert!(patchset.patches()[0].patch().hunks().is_empty());
+    }
+
+    #[test]
+    fn empty_file_delete() {
+        let content = "\
+diff --git a/empty.txt b/empty.txt
+deleted file mode 100644
+index e69de29..0000000
+";
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Delete("a/empty.txt".to_owned())
+        );
+        assert!(patchset.patches()[0].patch().hunks().is_empty());
+    }
+
+    #[test]
     fn pure_rename() {
         let content = "\
 diff --git a/old.txt b/new.txt
@@ -536,6 +571,37 @@ copy to copy.txt
     }
 
     #[test]
+    fn rename_with_mode_change() {
+        // Rename + mode change can coexist in a single patch
+        let content = "\
+diff --git a/file.sh b/renamed.sh
+old mode 100644
+new mode 100755
+similarity index 100%
+rename from file.sh
+rename to renamed.sh
+";
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+
+        // Operation is Rename; mode change is orthogonal metadata
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Rename {
+                from: "file.sh".to_owned(),
+                to: "renamed.sh".to_owned(),
+            }
+        );
+        assert!(patchset.patches()[0].patch().hunks().is_empty());
+
+        assert_eq!(patchset.patches()[0].old_mode(), Some(&FileMode::Regular));
+        assert_eq!(
+            patchset.patches()[0].new_mode(),
+            Some(&FileMode::Executable)
+        );
+    }
+
+    #[test]
     fn format_patch_with_preamble() {
         let content = "\
 From abc123 Mon Sep 17 00:00:00 2001
@@ -567,25 +633,263 @@ diff --git a/file.rs b/file.rs
     }
 
     #[test]
-    fn mode_only_change_not_supported() {
+    fn mode_only_change() {
         let content = "\
 diff --git a/script.sh b/script.sh
 old mode 100644
 new mode 100755
 ";
-        let result = PatchSet::parse(content, ParseMode::GitDiff);
-        assert!(result.is_err());
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+
+        // Mode-only change is represented as Modify with empty hunks
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Modify {
+                original: "a/script.sh".to_owned(),
+                modified: "b/script.sh".to_owned(),
+            }
+        );
+        assert!(patchset.patches()[0].patch().hunks().is_empty());
+
+        assert_eq!(patchset.patches()[0].old_mode(), Some(&FileMode::Regular));
+        assert_eq!(
+            patchset.patches()[0].new_mode(),
+            Some(&FileMode::Executable)
+        );
     }
 
     #[test]
-    fn binary_file_not_supported() {
+    fn mode_only_no_prefix() {
+        // `git diff --no-prefix`: both sides identical, handled by special case.
+        let content = "\
+diff --git script.sh script.sh
+old mode 100644
+new mode 100755
+";
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Modify {
+                original: "script.sh".to_owned(),
+                modified: "script.sh".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn mode_only_paths_with_spaces() {
+        let content = "\
+diff --git a/script name.sh b/script name.sh
+old mode 100644
+new mode 100755
+";
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Modify {
+                original: "a/script name.sh".to_owned(),
+                modified: "b/script name.sh".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn mode_only_path_containing_space_b_slash() {
+        // Path contains ` b/` which could confuse naive "split at ` b/`" parsing.
+        let content = "\
+diff --git a/path/to/my b/file.txt b/path/to/my b/file.txt
+old mode 100644
+new mode 100755
+";
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Modify {
+                original: "a/path/to/my b/file.txt".to_owned(),
+                modified: "b/path/to/my b/file.txt".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn mode_only_custom_prefix() {
+        let content = "\
+diff --git src/script.sh dst/script.sh
+old mode 100644
+new mode 100755
+";
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Modify {
+                original: "src/script.sh".to_owned(),
+                modified: "dst/script.sh".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn mode_only_different_prefix_depths() {
+        // Custom prefixes with different directory depths.
+        let content = "\
+diff --git src/main/java/file.txt target/file.txt
+old mode 100644
+new mode 100755
+";
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Modify {
+                original: "src/main/java/file.txt".to_owned(),
+                modified: "target/file.txt".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn mode_only_quoted_with_escapes() {
+        // Quoted paths with escape sequences (tab, backslash).
+        let content = "\
+diff --git \"a/file\\twith\\ttab.sh\" \"b/file\\twith\\ttab.sh\"
+old mode 100644
+new mode 100755
+";
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Modify {
+                original: "a/file\twith\ttab.sh".to_owned(),
+                modified: "b/file\twith\ttab.sh".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn mode_only_old_quoted_new_unquoted() {
+        // Old path quoted (with escape in prefix), new path unquoted.
+        let content = "\
+diff --git \"a\\t/script.sh\" b/script.sh
+old mode 100644
+new mode 100755
+";
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Modify {
+                original: "a\t/script.sh".to_owned(),
+                modified: "b/script.sh".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn mode_only_old_unquoted_new_quoted() {
+        // Old path unquoted, new path quoted (with escape in prefix).
+        let content = "\
+diff --git a/script.sh \"b\\t/script.sh\"
+old mode 100644
+new mode 100755
+";
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Modify {
+                original: "a/script.sh".to_owned(),
+                modified: "b\t/script.sh".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn mode_only_ambiguous_splits() {
+        // Multiple space positions could split the line; algorithm picks longest suffix.
+        // `--src-prefix="src/foo.rs "` produces this pathological case.
+        let content = "\
+diff --git src/foo.rs src/foo.rs src/foo.rs src/foo.rs
+old mode 100644
+new mode 100755
+";
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Modify {
+                original: "src/foo.rs src/foo.rs".to_owned(),
+                modified: "src/foo.rs src/foo.rs".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn mode_only_path_component_boundary() {
+        // "fofoo/bar.rs" vs "foo/bar.rs": suffix stops at `/` boundary.
+        let content = "\
+diff --git fofoo/bar.rs foo/bar.rs
+old mode 100644
+new mode 100755
+";
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Modify {
+                original: "fofoo/bar.rs".to_owned(),
+                modified: "foo/bar.rs".to_owned(),
+            }
+        );
+    }
+
+    #[test]
+    fn mode_only_mismatched_paths_error() {
+        // Different filenames: no valid common suffix, should fail to parse.
+        let content = "\
+diff --git a/foo.rs b/bar.rs
+old mode 100644
+new mode 100755
+";
+        assert!(PatchSet::parse(content, ParseMode::GitDiff).is_err());
+    }
+
+    #[test]
+    fn mode_only_empty_filename_error() {
+        // Trailing slash means empty filename, should fail.
+        let content = "\
+diff --git a/ b/
+old mode 100644
+new mode 100755
+";
+        assert!(PatchSet::parse(content, ParseMode::GitDiff).is_err());
+    }
+
+    #[test]
+    fn binary_file() {
         let content = "\
 diff --git a/image.png b/image.png
 index 1234567..89abcdef 100644
 Binary files a/image.png and b/image.png differ
 ";
-        let result = PatchSet::parse(content, ParseMode::GitDiff);
-        assert!(result.is_err());
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 1);
+
+        // Binary file is represented as Modify with empty hunks
+        // TODO: true binary patch support
+        assert_eq!(
+            patchset.patches()[0].operation(),
+            &FileOperation::Modify {
+                original: "a/image.png".to_owned(),
+                modified: "b/image.png".to_owned(),
+            }
+        );
+        assert!(patchset.patches()[0].patch().hunks().is_empty());
     }
 
     #[test]
@@ -640,8 +944,7 @@ diff --git a/file.rs b/file.rs
     #[test]
     fn multiple_separator_in_commit_message() {
         // Git uses the first `\n---\n` as separator (observed git mailinfo behavior).
-        // The fake `diff --git` after first separator becomes a real patch boundary,
-        // but lacks `---`/`+++` headers, causing a parse error.
+        // The fake `diff --git` after first separator becomes a real patch boundary.
         let content = "\
 From abc123 Mon Sep 17 00:00:00 2001
 Subject: [PATCH] test
@@ -661,9 +964,11 @@ diff --git a/real.rs b/real.rs
 +change
 ";
         // First `---` strips preamble, exposing fake `diff --git` as patch boundary.
-        // The fake patch has no `---`/`+++` headers, so parsing fails.
-        let result = PatchSet::parse(content, ParseMode::GitDiff);
-        assert!(result.is_err());
+        // fake has no `---`/`+++` headers, parsed as Modify with empty hunks.
+        let patchset = PatchSet::parse(content, ParseMode::GitDiff).unwrap();
+        assert_eq!(patchset.len(), 2);
+        assert!(patchset.patches()[0].patch().hunks().is_empty());
+        assert_eq!(patchset.patches()[1].patch().hunks().len(), 1);
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -242,6 +242,24 @@ fn find_byte(haystack: &[u8], byte: u8) -> Option<usize> {
 ///
 /// See [`ESCAPED_CHARS`] for supported escapes.
 pub(crate) fn escaped_filename<T: Text + ToOwned + ?Sized>(
+    filename: &T,
+) -> Result<Cow<'_, [u8]>, ParsePatchError> {
+    let is_quoted = filename
+        .strip_prefix("\"")
+        .and_then(|s| s.strip_suffix("\""));
+    if let Some(inner) = is_quoted {
+        _escaped_filename(inner)
+    } else {
+        // No need to escape
+        let bytes = filename.as_bytes();
+        if bytes.iter().any(|b| ESCAPED_CHARS_BYTES.contains(b)) {
+            return Err(ParsePatchError::new("invalid char in unquoted filename"));
+        }
+        Ok(bytes.into())
+    }
+}
+
+fn _escaped_filename<T: Text + ToOwned + ?Sized>(
     escaped: &T,
 ) -> Result<Cow<'_, [u8]>, ParsePatchError> {
     let bytes = escaped.as_bytes();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -244,15 +244,23 @@ fn find_byte(haystack: &[u8], byte: u8) -> Option<usize> {
 pub(crate) fn escaped_filename<T: Text + ToOwned + ?Sized>(
     escaped: &T,
 ) -> Result<Cow<'_, [u8]>, ParsePatchError> {
-    let mut filename = Vec::new();
+    let bytes = escaped.as_bytes();
+    let mut result = Vec::new();
+    let mut i = 0;
+    let mut last_copy = 0;
+    let mut needs_allocation = false;
 
-    let mut chars = escaped.as_bytes().iter().copied();
-    while let Some(c) = chars.next() {
-        if c == b'\\' {
-            let ch = match chars
-                .next()
-                .ok_or_else(|| ParsePatchError::new("expected escaped character"))?
-            {
+    while i < bytes.len() {
+        if bytes[i] == b'\\' {
+            needs_allocation = true;
+            result.extend_from_slice(&bytes[last_copy..i]);
+
+            i += 1;
+            if i >= bytes.len() {
+                return Err(ParsePatchError::new("expected escaped character"));
+            }
+
+            let decoded = match bytes[i] {
                 b'n' => b'\n',
                 b't' => b'\t',
                 b'0' => b'\0',
@@ -261,13 +269,20 @@ pub(crate) fn escaped_filename<T: Text + ToOwned + ?Sized>(
                 b'\\' => b'\\',
                 _ => return Err(ParsePatchError::new("invalid escaped character")),
             };
-            filename.push(ch);
-        } else if ESCAPED_CHARS_BYTES.contains(&c) {
+            result.push(decoded);
+            i += 1;
+            last_copy = i;
+        } else if ESCAPED_CHARS_BYTES.contains(&bytes[i]) {
             return Err(ParsePatchError::new("invalid unescaped character"));
         } else {
-            filename.push(c);
+            i += 1;
         }
     }
 
-    Ok(filename.into())
+    if needs_allocation {
+        result.extend_from_slice(&bytes[last_copy..]);
+        Ok(Cow::Owned(result))
+    } else {
+        Ok(Cow::Borrowed(bytes))
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,19 @@
 //! Common utilities
 
 use std::{
+    borrow::Cow,
     collections::{hash_map::Entry, HashMap},
     hash::Hash,
 };
+
+use crate::ParsePatchError;
+
+/// Characters that require escaping in filenames.
+pub const ESCAPED_CHARS: &[char] = &['\n', '\t', '\0', '\r', '\"', '\\'];
+
+/// Like [`ESCAPED_CHARS`] but in byte representation.
+#[allow(clippy::byte_char_slices)]
+pub const ESCAPED_CHARS_BYTES: &[u8] = &[b'\n', b'\t', b'\0', b'\r', b'\"', b'\\'];
 
 /// Classifies lines, converting lines into unique `u64`s for quicker comparison
 pub struct Classifier<'a, T: ?Sized> {
@@ -226,4 +236,38 @@ fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
 // XXX Maybe use `memchr`?
 fn find_byte(haystack: &[u8], byte: u8) -> Option<usize> {
     haystack.iter().position(|&b| b == byte)
+}
+
+/// Decodes escape sequences in a quoted filename.
+///
+/// See [`ESCAPED_CHARS`] for supported escapes.
+pub(crate) fn escaped_filename<T: Text + ToOwned + ?Sized>(
+    escaped: &T,
+) -> Result<Cow<'_, [u8]>, ParsePatchError> {
+    let mut filename = Vec::new();
+
+    let mut chars = escaped.as_bytes().iter().copied();
+    while let Some(c) = chars.next() {
+        if c == b'\\' {
+            let ch = match chars
+                .next()
+                .ok_or_else(|| ParsePatchError::new("expected escaped character"))?
+            {
+                b'n' => b'\n',
+                b't' => b'\t',
+                b'0' => b'\0',
+                b'r' => b'\r',
+                b'\"' => b'\"',
+                b'\\' => b'\\',
+                _ => return Err(ParsePatchError::new("invalid escaped character")),
+            };
+            filename.push(ch);
+        } else if ESCAPED_CHARS_BYTES.contains(&c) {
+            return Err(ParsePatchError::new("invalid unescaped character"));
+        } else {
+            filename.push(c);
+        }
+    }
+
+    Ok(filename.into())
 }


### PR DESCRIPTION
Add support for parsing patches without `---`/`+++` headers
(mode-only changes, binary files, empty file creation/deletion)
by parsing paths from `diff --git` line.

Some implementation notes:

- Parse `diff --git` paths using heuristic longest common path suffix algorithm, matching observed `git apply` behavior as it could be ambiguous. See code comment for more.
- Add `FileMode` enum and expose `old_mode()`/`new_mode()` on `FilePatch`. Caller should handle mode change additionally after working on `FileOperation`.
