### PR TITLE
fix(patchset): propagate new/deleted file mode

### DIFF
--- a/src/patchset/mod.rs
+++ b/src/patchset/mod.rs
@@ -216,12 +216,22 @@ impl<'a, T: ToOwned + ?Sized> FilePatch<'a, T> {
         self.patch
     }
 
-    /// Returns the old file mode, if present.
+    /// Returns the file mode before applying this patch (when known).
+    ///
+    /// This is typically populated for
+    ///
+    /// * mode changes (`old mode <mode>` header)
+    /// * deletions (`deleted file mode <mode>` header)
     pub fn old_mode(&self) -> Option<&FileMode> {
         self.old_mode.as_ref()
     }
 
-    /// Returns the new file mode, if present.
+    /// Returns the file mode **after** applying this patch (when known).
+    ///
+    /// This is typically populated for
+    ///
+    /// * mode changes (the `new mode <mode>` header)
+    /// * creations (the `new file mode <mode>` header)
     pub fn new_mode(&self) -> Option<&FileMode> {
         self.new_mode.as_ref()
     }

--- a/src/patchset/parse.rs
+++ b/src/patchset/parse.rs
@@ -40,8 +40,16 @@ fn parse_gitdiff(input: &str) -> Result<PatchSet<'_, str>, PatchSetParseError> {
         let patch =
             Patch::from_str(raw.patch).map_err(|e| PatchSetParseError::new(e.to_string()))?;
         let operation = extract_file_op_gitdiff(&header, &patch)?;
-        let old_mode = header.old_mode.map(str::parse::<FileMode>).transpose()?;
-        let new_mode = header.new_mode.map(str::parse::<FileMode>).transpose()?;
+        let old_mode = header
+            .old_mode
+            .or(header.deleted_file_mode)
+            .map(str::parse::<FileMode>)
+            .transpose()?;
+        let new_mode = header
+            .new_mode
+            .or(header.new_file_mode)
+            .map(str::parse::<FileMode>)
+            .transpose()?;
         patches.push(FilePatch::new(operation, patch, old_mode, new_mode));
     }
 

--- a/src/patchset/tests.rs
+++ b/src/patchset/tests.rs
@@ -122,7 +122,10 @@ new file mode 100755
         );
         assert_eq!(patchset.patches()[0].patch().hunks().len(), 1);
         assert_eq!(patchset.patches()[0].old_mode(), None);
-        assert_eq!(patchset.patches()[0].new_mode(), None);
+        assert_eq!(
+            patchset.patches()[0].new_mode(),
+            Some(&FileMode::Executable)
+        );
     }
 
     #[test]
@@ -143,7 +146,10 @@ deleted file mode 100755
             &FileOperation::Delete("a/old.sh".to_owned().into())
         );
         assert_eq!(patchset.patches()[0].patch().hunks().len(), 1);
-        assert_eq!(patchset.patches()[0].old_mode(), None);
+        assert_eq!(
+            patchset.patches()[0].old_mode(),
+            Some(&FileMode::Executable)
+        );
         assert_eq!(patchset.patches()[0].new_mode(), None);
     }
 
@@ -163,7 +169,7 @@ index 0000000..e69de29
         );
         assert!(patchset.patches()[0].patch().hunks().is_empty());
         assert_eq!(patchset.patches()[0].old_mode(), None);
-        assert_eq!(patchset.patches()[0].new_mode(), None);
+        assert_eq!(patchset.patches()[0].new_mode(), Some(&FileMode::Regular));
     }
 
     #[test]
@@ -181,7 +187,7 @@ index e69de29..0000000
             &FileOperation::Delete("a/empty.txt".to_owned().into())
         );
         assert!(patchset.patches()[0].patch().hunks().is_empty());
-        assert_eq!(patchset.patches()[0].old_mode(), None);
+        assert_eq!(patchset.patches()[0].old_mode(), Some(&FileMode::Regular));
         assert_eq!(patchset.patches()[0].new_mode(), None);
     }
 

--- a/src/patchset/tests.rs
+++ b/src/patchset/tests.rs
@@ -96,6 +96,11 @@ new mode 100755
             }
         );
         assert_eq!(patchset.patches()[0].patch().hunks().len(), 1);
+        assert_eq!(patchset.patches()[0].old_mode(), Some(&FileMode::Regular));
+        assert_eq!(
+            patchset.patches()[0].new_mode(),
+            Some(&FileMode::Executable)
+        );
     }
 
     #[test]
@@ -116,6 +121,8 @@ new file mode 100755
             &FileOperation::Create("b/new.sh".to_owned().into())
         );
         assert_eq!(patchset.patches()[0].patch().hunks().len(), 1);
+        assert_eq!(patchset.patches()[0].old_mode(), None);
+        assert_eq!(patchset.patches()[0].new_mode(), None);
     }
 
     #[test]
@@ -136,6 +143,8 @@ deleted file mode 100755
             &FileOperation::Delete("a/old.sh".to_owned().into())
         );
         assert_eq!(patchset.patches()[0].patch().hunks().len(), 1);
+        assert_eq!(patchset.patches()[0].old_mode(), None);
+        assert_eq!(patchset.patches()[0].new_mode(), None);
     }
 
     #[test]
@@ -153,6 +162,8 @@ index 0000000..e69de29
             &FileOperation::Create("b/empty.txt".to_owned().into())
         );
         assert!(patchset.patches()[0].patch().hunks().is_empty());
+        assert_eq!(patchset.patches()[0].old_mode(), None);
+        assert_eq!(patchset.patches()[0].new_mode(), None);
     }
 
     #[test]
@@ -170,6 +181,8 @@ index e69de29..0000000
             &FileOperation::Delete("a/empty.txt".to_owned().into())
         );
         assert!(patchset.patches()[0].patch().hunks().is_empty());
+        assert_eq!(patchset.patches()[0].old_mode(), None);
+        assert_eq!(patchset.patches()[0].new_mode(), None);
     }
 
     #[test]


### PR DESCRIPTION
Git diff patches that use `new file mode` / `deleted file mode`
previously reported `old_mode()` / `new_mode()` as `None`,
even though the mode is present in the header.

Treat these headers as the effective after/before mode
so create/delete patches expose a consistent "before/after" mode view.