### PR TITLE
chore(ci): replay full history for selected repos

### DIFF
--- a/.github/workflows/replay-full.yml
+++ b/.github/workflows/replay-full.yml
@@ -1,0 +1,29 @@
+name: Replay (Full History)
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches:
+      - git-format-patch
+
+jobs:
+  replay-full:
+    strategy:
+      matrix:
+        include:
+          - name: rust-lang/cargo
+            repo_url: https://github.com/rust-lang/cargo
+          - name: rust-lang/rustup
+            repo_url: https://github.com/rust-lang/rustup
+          - name: rust-lang/rust-analyzer
+            repo_url: https://github.com/rust-lang/rust-analyzer
+          - name: rust-lang/rust-clippy
+            repo_url: https://github.com/rust-lang/rust-clippy
+    name: ${{ matrix.name }}
+    uses: ./.github/workflows/replay.yml
+    with:
+      name: ${{ matrix.name }}
+      repo_url: ${{ matrix.repo_url }}
+      commits: '0'


### PR DESCRIPTION
Only when merging into the "main" branch
(currently our main branch is git-format-patch)