### PR TITLE
refactor(error): conver error types to enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,7 +121,7 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "diffy"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "anstyle",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diffy"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["Brandon Williams <bwilliams.eng@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Tools for finding and manipulating differences between files"

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -76,7 +76,7 @@ impl<'a> BinaryPatch<'a> {
     pub fn apply(&self, original: &[u8]) -> Result<Vec<u8>, BinaryPatchParseError> {
         match self {
             BinaryPatch::Full { forward, .. } => Self::apply_block(forward, original),
-            BinaryPatch::Marker => Err(BinaryPatchParseError::new("no binary data available")),
+            BinaryPatch::Marker => Err(BinaryPatchParseError::NoBinaryData),
         }
     }
 
@@ -90,7 +90,7 @@ impl<'a> BinaryPatch<'a> {
     pub fn apply_reverse(&self, modified: &[u8]) -> Result<Vec<u8>, BinaryPatchParseError> {
         match self {
             BinaryPatch::Full { reverse, .. } => Self::apply_block(reverse, modified),
-            BinaryPatch::Marker => Err(BinaryPatchParseError::new("no binary data available")),
+            BinaryPatch::Marker => Err(BinaryPatchParseError::NoBinaryData),
         }
     }
 
@@ -101,8 +101,7 @@ impl<'a> BinaryPatch<'a> {
             BinaryBlockKind::Literal => Self::decode_data(&block.data),
             BinaryBlockKind::Delta => {
                 let delta_instructions = Self::decode_data(&block.data)?;
-                delta::apply(base, &delta_instructions)
-                    .map_err(|e| BinaryPatchParseError::new(e.to_string()))
+                delta::apply(base, &delta_instructions).map_err(BinaryPatchParseError::from)
             }
         }
     }
@@ -118,7 +117,7 @@ impl<'a> BinaryPatch<'a> {
         let mut decompressed = Vec::new();
         decoder
             .read_to_end(&mut decompressed)
-            .map_err(|e| BinaryPatchParseError::new(format!("decompression failed: {e}")))?;
+            .map_err(|e| BinaryPatchParseError::DecompressionFailed(e.to_string()))?;
 
         Ok(decompressed)
     }
@@ -208,12 +207,12 @@ pub(crate) fn parse_binary_patch(input: &str) -> Result<BinaryPatch<'_>, BinaryP
 
     // Parse first block (forward: original -> modified)
     let Some(forward) = parse_binary_block(&mut parser) else {
-        return Err(BinaryPatchParseError::new("first binary block not found"));
+        return Err(BinaryPatchParseError::MissingForwardBlock);
     };
 
     // Parse second block (reverse: modified -> original)
     let Some(reverse) = parse_binary_block(&mut parser) else {
-        return Err(BinaryPatchParseError::new("second binary block not found"));
+        return Err(BinaryPatchParseError::MissingReverseBlock);
     };
 
     Ok(BinaryPatch::Full { forward, reverse })
@@ -280,11 +279,10 @@ fn decode_base85_lines(data: &str) -> Result<Vec<u8>, BinaryPatchParseError> {
         let line_bytes = line.as_bytes();
 
         let length = decode_line_length(line_bytes[0])
-            .ok_or_else(|| BinaryPatchParseError::new("invalid line length indicator"))?;
+            .ok_or(BinaryPatchParseError::InvalidLineLengthIndicator)?;
         let encoded = &line[1..];
         let start = result.len();
-        base85::decode_into(encoded, &mut result)
-            .map_err(|e| BinaryPatchParseError::new(e.to_string()))?;
+        base85::decode_into(encoded, &mut result)?;
         result.truncate(start + length);
     }
 

--- a/src/binary.rs
+++ b/src/binary.rs
@@ -9,9 +9,9 @@
 mod base85;
 #[cfg(feature = "binary")]
 mod delta;
+mod error;
 
-use std::borrow::Cow;
-use std::fmt;
+pub use error::BinaryPatchParseError;
 
 /// The type of a binary patch block.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -310,24 +310,6 @@ fn decode_line_length(c: u8) -> Option<usize> {
         _ => None,
     }
 }
-
-/// Error type for binary patch operations.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BinaryPatchParseError(Cow<'static, str>);
-
-impl BinaryPatchParseError {
-    pub(crate) fn new<E: Into<Cow<'static, str>>>(e: E) -> Self {
-        Self(e.into())
-    }
-}
-
-impl fmt::Display for BinaryPatchParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl std::error::Error for BinaryPatchParseError {}
 
 #[cfg(test)]
 mod tests {

--- a/src/binary/error.rs
+++ b/src/binary/error.rs
@@ -1,0 +1,22 @@
+//! Error types for binary patch operations.
+
+use std::borrow::Cow;
+use std::fmt;
+
+/// Error type for binary patch operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BinaryPatchParseError(Cow<'static, str>);
+
+impl BinaryPatchParseError {
+    pub(crate) fn new<E: Into<Cow<'static, str>>>(e: E) -> Self {
+        Self(e.into())
+    }
+}
+
+impl fmt::Display for BinaryPatchParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for BinaryPatchParseError {}

--- a/src/binary/error.rs
+++ b/src/binary/error.rs
@@ -1,22 +1,70 @@
 //! Error types for binary patch operations.
 
-use std::borrow::Cow;
 use std::fmt;
+
+#[cfg(feature = "binary")]
+use super::base85::Base85Error;
+#[cfg(feature = "binary")]
+use super::delta::DeltaError;
 
 /// Error type for binary patch operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BinaryPatchParseError(Cow<'static, str>);
+#[non_exhaustive]
+pub enum BinaryPatchParseError {
+    /// Base85 decoding failed.
+    #[cfg(feature = "binary")]
+    Base85(Base85Error),
 
-impl BinaryPatchParseError {
-    pub(crate) fn new<E: Into<Cow<'static, str>>>(e: E) -> Self {
-        Self(e.into())
-    }
+    /// Delta application failed.
+    #[cfg(feature = "binary")]
+    Delta(DeltaError),
+
+    /// First binary block (forward) not found.
+    MissingForwardBlock,
+
+    /// Second binary block (reverse) not found.
+    MissingReverseBlock,
+
+    /// No binary data available (marker-only patch).
+    NoBinaryData,
+
+    /// Invalid line length indicator in Base85 data.
+    InvalidLineLengthIndicator,
+
+    /// Zlib decompression failed.
+    #[cfg(feature = "binary")]
+    DecompressionFailed(String),
 }
 
 impl fmt::Display for BinaryPatchParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        match self {
+            #[cfg(feature = "binary")]
+            Self::Base85(e) => write!(f, "{e}"),
+            #[cfg(feature = "binary")]
+            Self::Delta(e) => write!(f, "{e}"),
+            Self::MissingForwardBlock => write!(f, "first binary block not found"),
+            Self::MissingReverseBlock => write!(f, "second binary block not found"),
+            Self::NoBinaryData => write!(f, "no binary data available"),
+            Self::InvalidLineLengthIndicator => write!(f, "invalid line length indicator"),
+            #[cfg(feature = "binary")]
+            Self::DecompressionFailed(msg) => write!(f, "decompression failed: {msg}"),
+        }
     }
 }
 
 impl std::error::Error for BinaryPatchParseError {}
+
+#[cfg(feature = "binary")]
+impl From<Base85Error> for BinaryPatchParseError {
+    fn from(e: Base85Error) -> Self {
+        Self::Base85(e)
+    }
+}
+
+#[cfg(feature = "binary")]
+impl From<DeltaError> for BinaryPatchParseError {
+    fn from(e: DeltaError) -> Self {
+        Self::Delta(e)
+    }
+}

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -1,3 +1,4 @@
+mod error;
 mod format;
 pub(crate) mod parse;
 #[cfg(feature = "color")]
@@ -7,8 +8,8 @@ use std::borrow::Cow;
 use std::fmt;
 use std::ops;
 
+pub use error::ParsePatchError;
 pub use format::PatchFormatter;
-pub use parse::ParsePatchError;
 
 use crate::utils::ESCAPED_CHARS;
 use crate::utils::ESCAPED_CHARS_BYTES;

--- a/src/patch/error.rs
+++ b/src/patch/error.rs
@@ -1,24 +1,99 @@
 //! Error types for patch parsing.
 
-use std::borrow::Cow;
 use std::fmt;
 
-/// An error returned when parsing a `Patch` using [`Patch::from_str`] fails
+/// An error returned when parsing a `Patch` using [`Patch::from_str`] fails.
 ///
 /// [`Patch::from_str`]: struct.Patch.html#method.from_str
-// TODO use a custom error type instead of a Cow
-#[derive(Debug)]
-pub struct ParsePatchError(Cow<'static, str>);
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ParsePatchError {
+    /// Unexpected end of input.
+    UnexpectedEof,
 
-impl ParsePatchError {
-    pub(crate) fn new<E: Into<Cow<'static, str>>>(e: E) -> Self {
-        Self(e.into())
-    }
+    /// Multiple `---` lines found where only one expected.
+    MultipleOriginalHeaders,
+
+    /// Multiple `+++` lines found where only one expected.
+    MultipleModifiedHeaders,
+
+    /// Unable to parse filename from header line.
+    InvalidFilename,
+
+    /// Filename line missing newline or tab terminator.
+    FilenameUnterminated,
+
+    /// Invalid character in unquoted filename.
+    InvalidCharInUnquotedFilename,
+
+    /// Expected escaped character in quoted filename.
+    ExpectedEscapedChar,
+
+    /// Invalid escaped character in quoted filename.
+    InvalidEscapedChar,
+
+    /// Invalid unescaped character in quoted filename.
+    InvalidUnescapedChar,
+
+    /// Unable to parse hunk header (`@@ ... @@`).
+    InvalidHunkHeader,
+
+    /// Hunk header missing closing `@@`.
+    HunkHeaderUnterminated,
+
+    /// Unable to parse range in hunk header.
+    InvalidRange,
+
+    /// Hunks are not in order or overlap.
+    HunksOutOfOrder,
+
+    /// Hunk header line counts don't match actual content.
+    HunkMismatch,
+
+    /// Expected end of hunk after `\ No newline at end of file`.
+    ExpectedEndOfHunk,
+
+    /// Expected no more deleted lines in hunk.
+    TooManyDeletedLines,
+
+    /// Expected no more inserted lines in hunk.
+    TooManyInsertedLines,
+
+    /// Unexpected `\ No newline at end of file` marker.
+    UnexpectedNoNewlineMarker,
+
+    /// Unexpected line in hunk body.
+    UnexpectedHunkLine,
+
+    /// Missing newline at end of line.
+    MissingNewline,
 }
 
 impl fmt::Display for ParsePatchError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "error parsing patch: {}", self.0)
+        let msg = match self {
+            Self::UnexpectedEof => "unexpected EOF",
+            Self::MultipleOriginalHeaders => "multiple '---' lines",
+            Self::MultipleModifiedHeaders => "multiple '+++' lines",
+            Self::InvalidFilename => "unable to parse filename",
+            Self::FilenameUnterminated => "filename unterminated",
+            Self::InvalidCharInUnquotedFilename => "invalid char in unquoted filename",
+            Self::ExpectedEscapedChar => "expected escaped character",
+            Self::InvalidEscapedChar => "invalid escaped character",
+            Self::InvalidUnescapedChar => "invalid unescaped character",
+            Self::InvalidHunkHeader => "unable to parse hunk header",
+            Self::HunkHeaderUnterminated => "hunk header unterminated",
+            Self::InvalidRange => "can't parse range",
+            Self::HunksOutOfOrder => "hunks not in order or overlap",
+            Self::HunkMismatch => "hunk header does not match hunk",
+            Self::ExpectedEndOfHunk => "expected end of hunk",
+            Self::TooManyDeletedLines => "expected no more deleted lines",
+            Self::TooManyInsertedLines => "expected no more inserted lines",
+            Self::UnexpectedNoNewlineMarker => "unexpected 'No newline at end of file' line",
+            Self::UnexpectedHunkLine => "unexpected line in hunk body",
+            Self::MissingNewline => "missing newline",
+        };
+        write!(f, "error parsing patch: {msg}")
     }
 }
 

--- a/src/patch/error.rs
+++ b/src/patch/error.rs
@@ -1,0 +1,25 @@
+//! Error types for patch parsing.
+
+use std::borrow::Cow;
+use std::fmt;
+
+/// An error returned when parsing a `Patch` using [`Patch::from_str`] fails
+///
+/// [`Patch::from_str`]: struct.Patch.html#method.from_str
+// TODO use a custom error type instead of a Cow
+#[derive(Debug)]
+pub struct ParsePatchError(Cow<'static, str>);
+
+impl ParsePatchError {
+    pub(crate) fn new<E: Into<Cow<'static, str>>>(e: E) -> Self {
+        Self(e.into())
+    }
+}
+
+impl fmt::Display for ParsePatchError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "error parsing patch: {}", self.0)
+    }
+}
+
+impl std::error::Error for ParsePatchError {}

--- a/src/patch/parse.rs
+++ b/src/patch/parse.rs
@@ -1,8 +1,8 @@
 //! Parse a Patch
 
 use std::borrow::Cow;
-use std::fmt;
 
+use super::error::ParsePatchError;
 use super::Hunk;
 use super::HunkRange;
 use super::Line;
@@ -13,27 +13,6 @@ use crate::utils::LineIter;
 use crate::utils::Text;
 
 type Result<T, E = ParsePatchError> = std::result::Result<T, E>;
-
-/// An error returned when parsing a `Patch` using [`Patch::from_str`] fails
-///
-/// [`Patch::from_str`]: struct.Patch.html#method.from_str
-// TODO use a custom error type instead of a Cow
-#[derive(Debug)]
-pub struct ParsePatchError(Cow<'static, str>);
-
-impl ParsePatchError {
-    pub(crate) fn new<E: Into<Cow<'static, str>>>(e: E) -> Self {
-        Self(e.into())
-    }
-}
-
-impl fmt::Display for ParsePatchError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "error parsing patch: {}", self.0)
-    }
-}
-
-impl std::error::Error for ParsePatchError {}
 
 struct Parser<'a, T: Text + ?Sized> {
     lines: std::iter::Peekable<LineIter<'a, T>>,

--- a/src/patch/parse.rs
+++ b/src/patch/parse.rs
@@ -375,7 +375,10 @@ that should be ignored
 garbage before hunk complete
  line 3
 ";
-        assert!(parse(s).is_err());
+        assert_eq!(
+            parse(s).unwrap_err(),
+            super::ParsePatchError::UnexpectedHunkLine
+        );
     }
 
     #[test]

--- a/src/patch/parse.rs
+++ b/src/patch/parse.rs
@@ -32,10 +32,7 @@ impl<'a, T: Text + ?Sized> Parser<'a, T> {
     }
 
     fn next(&mut self) -> Result<&'a T> {
-        let line = self
-            .lines
-            .next()
-            .ok_or_else(|| ParsePatchError::new("unexpected EOF"))?;
+        let line = self.lines.next().ok_or(ParsePatchError::UnexpectedEof)?;
         self.offset += line.len();
         Ok(line)
     }
@@ -92,12 +89,12 @@ fn patch_header<'a, T: Text + ToOwned + ?Sized>(
     while let Some(line) = parser.peek() {
         if line.starts_with("--- ") {
             if filename1.is_some() {
-                return Err(ParsePatchError::new("multiple '---' lines"));
+                return Err(ParsePatchError::MultipleOriginalHeaders);
             }
             filename1 = Some(parse_filename("--- ", parser.next()?)?);
         } else if line.starts_with("+++ ") {
             if filename2.is_some() {
-                return Err(ParsePatchError::new("multiple '+++' lines"));
+                return Err(ParsePatchError::MultipleModifiedHeaders);
             }
             filename2 = Some(parse_filename("+++ ", parser.next()?)?);
         } else {
@@ -127,14 +124,14 @@ fn parse_filename<'a, T: Text + ToOwned + ?Sized>(
 ) -> Result<Cow<'a, [u8]>> {
     let line = line
         .strip_prefix(prefix)
-        .ok_or_else(|| ParsePatchError::new("unable to parse filename"))?;
+        .ok_or(ParsePatchError::InvalidFilename)?;
 
     let filename = if let Some((filename, _)) = line.split_at_exclusive("\t") {
         filename
     } else if let Some((filename, _)) = line.split_at_exclusive("\n") {
         filename
     } else {
-        return Err(ParsePatchError::new("filename unterminated"));
+        return Err(ParsePatchError::FilenameUnterminated);
     };
 
     let filename = escaped_filename(filename)?;
@@ -167,7 +164,7 @@ fn hunks<'a, T: Text + ?Sized>(parser: &mut Parser<'a, T>) -> Result<Vec<Hunk<'a
 
     // check and verify that the Hunks are in sorted order and don't overlap
     if !verify_hunks_in_order(&hunks) {
-        return Err(ParsePatchError::new("Hunks not in order or overlap"));
+        return Err(ParsePatchError::HunksOutOfOrder);
     }
 
     Ok(hunks)
@@ -183,25 +180,25 @@ fn hunk<'a, T: Text + ?Sized>(parser: &mut Parser<'a, T>) -> Result<Hunk<'a, T>>
 fn hunk_header<T: Text + ?Sized>(input: &T) -> Result<(HunkRange, HunkRange, Option<&T>)> {
     let input = input
         .strip_prefix("@@ ")
-        .ok_or_else(|| ParsePatchError::new("unable to parse hunk header"))?;
+        .ok_or(ParsePatchError::InvalidHunkHeader)?;
 
     let (ranges, function_context) = input
         .split_at_exclusive(" @@")
-        .ok_or_else(|| ParsePatchError::new("hunk header unterminated"))?;
+        .ok_or(ParsePatchError::HunkHeaderUnterminated)?;
     let function_context = function_context.strip_prefix(" ");
 
     let (range1, range2) = ranges
         .split_at_exclusive(" ")
-        .ok_or_else(|| ParsePatchError::new("unable to parse hunk header"))?;
+        .ok_or(ParsePatchError::InvalidHunkHeader)?;
     let range1 = range(
         range1
             .strip_prefix("-")
-            .ok_or_else(|| ParsePatchError::new("unable to parse hunk header"))?,
+            .ok_or(ParsePatchError::InvalidHunkHeader)?,
     )?;
     let range2 = range(
         range2
             .strip_prefix("+")
-            .ok_or_else(|| ParsePatchError::new("unable to parse hunk header"))?,
+            .ok_or(ParsePatchError::InvalidHunkHeader)?,
     )?;
     Ok((range1, range2, function_context))
 }
@@ -209,18 +206,11 @@ fn hunk_header<T: Text + ?Sized>(input: &T) -> Result<(HunkRange, HunkRange, Opt
 fn range<T: Text + ?Sized>(s: &T) -> Result<HunkRange> {
     let (start, len) = if let Some((start, len)) = s.split_at_exclusive(",") {
         (
-            start
-                .parse()
-                .ok_or_else(|| ParsePatchError::new("can't parse range"))?,
-            len.parse()
-                .ok_or_else(|| ParsePatchError::new("can't parse range"))?,
+            start.parse().ok_or(ParsePatchError::InvalidRange)?,
+            len.parse().ok_or(ParsePatchError::InvalidRange)?,
         )
     } else {
-        (
-            s.parse()
-                .ok_or_else(|| ParsePatchError::new("can't parse range"))?,
-            1,
-        )
+        (s.parse().ok_or(ParsePatchError::InvalidRange)?, 1)
     };
 
     Ok(HunkRange::new(start, len))
@@ -253,7 +243,7 @@ fn hunk_lines<'a, T: Text + ?Sized>(
             if hunk_complete {
                 break;
             }
-            return Err(ParsePatchError::new("expected end of hunk"));
+            return Err(ParsePatchError::ExpectedEndOfHunk);
         } else if let Some(line) = line.strip_prefix(" ") {
             if hunk_complete {
                 break;
@@ -266,7 +256,7 @@ fn hunk_lines<'a, T: Text + ?Sized>(
             Line::Context(*line)
         } else if let Some(line) = line.strip_prefix("-") {
             if no_newline_delete {
-                return Err(ParsePatchError::new("expected no more deleted lines"));
+                return Err(ParsePatchError::TooManyDeletedLines);
             }
             if hunk_complete {
                 break;
@@ -274,7 +264,7 @@ fn hunk_lines<'a, T: Text + ?Sized>(
             Line::Delete(line)
         } else if let Some(line) = line.strip_prefix("+") {
             if no_newline_insert {
-                return Err(ParsePatchError::new("expected no more inserted lines"));
+                return Err(ParsePatchError::TooManyInsertedLines);
             }
             if hunk_complete {
                 break;
@@ -288,9 +278,9 @@ fn hunk_lines<'a, T: Text + ?Sized>(
             //
             // * strip the newline character of the previous line
             // * don't increment line counts and continue to next directly
-            let last_line = lines.pop().ok_or_else(|| {
-                ParsePatchError::new("unexpected 'No newline at end of file' line")
-            })?;
+            let last_line = lines
+                .pop()
+                .ok_or(ParsePatchError::UnexpectedNoNewlineMarker)?;
             let modified = match last_line {
                 Line::Context(line) => {
                     no_newline_context = true;
@@ -314,7 +304,7 @@ fn hunk_lines<'a, T: Text + ?Sized>(
                 // Hunk is complete, treat remaining content as garbage
                 break;
             } else {
-                return Err(ParsePatchError::new("unexpected line in hunk body"));
+                return Err(ParsePatchError::UnexpectedHunkLine);
             }
         };
 
@@ -337,7 +327,7 @@ fn hunk_lines<'a, T: Text + ?Sized>(
 
     // Final check: ensure we got the expected number of lines
     if old_count != expected_old || new_count != expected_new {
-        return Err(ParsePatchError::new("Hunk header does not match hunk"));
+        return Err(ParsePatchError::HunkMismatch);
     }
 
     Ok(lines)
@@ -347,7 +337,7 @@ fn strip_newline<T: Text + ?Sized>(s: &T) -> Result<&T> {
     if let Some(stripped) = s.strip_suffix("\n") {
         Ok(stripped)
     } else {
-        Err(ParsePatchError::new("missing newline"))
+        Err(ParsePatchError::MissingNewline)
     }
 }
 

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -3,16 +3,18 @@
 //! This module provides [`Patches`] for parsing patches that contain changes
 //! to multiple files, like the output of `git diff` or `git format-patch`.
 
+mod error;
 mod parse;
-pub use parse::Patches;
 #[cfg(test)]
 mod tests;
 
 use std::borrow::Cow;
-use std::fmt;
 
 use crate::binary::BinaryPatch;
 use crate::Patch;
+
+pub use error::PatchSetParseError;
+pub use parse::Patches;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) enum Format {
@@ -402,21 +404,3 @@ impl FileOperation<'_> {
         matches!(self, FileOperation::Copy { .. })
     }
 }
-
-/// An error returned when parsing patches fails.
-#[derive(Debug)]
-pub struct PatchSetParseError(Cow<'static, str>);
-
-impl PatchSetParseError {
-    pub(crate) fn new<E: Into<Cow<'static, str>>>(e: E) -> Self {
-        Self(e.into())
-    }
-}
-
-impl fmt::Display for PatchSetParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "error parsing patchset: {}", self.0)
-    }
-}
-
-impl std::error::Error for PatchSetParseError {}

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -168,9 +168,7 @@ impl std::str::FromStr for FileMode {
             "100755" => Ok(Self::Executable),
             "120000" => Ok(Self::Symlink),
             "160000" => Ok(Self::Gitlink),
-            _ => Err(PatchSetParseError::new(format!(
-                "invalid file mode: {mode}"
-            ))),
+            _ => Err(PatchSetParseError::InvalidFileMode(mode.to_owned())),
         }
     }
 }

--- a/src/patches.rs
+++ b/src/patches.rs
@@ -13,7 +13,7 @@ use std::borrow::Cow;
 use crate::binary::BinaryPatch;
 use crate::Patch;
 
-pub use error::PatchSetParseError;
+pub use error::PatchesParseError;
 pub use parse::Patches;
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -160,7 +160,7 @@ pub enum FileMode {
 }
 
 impl std::str::FromStr for FileMode {
-    type Err = PatchSetParseError;
+    type Err = PatchesParseError;
 
     fn from_str(mode: &str) -> Result<Self, Self::Err> {
         match mode {
@@ -168,7 +168,7 @@ impl std::str::FromStr for FileMode {
             "100755" => Ok(Self::Executable),
             "120000" => Ok(Self::Symlink),
             "160000" => Ok(Self::Gitlink),
-            _ => Err(PatchSetParseError::InvalidFileMode(mode.to_owned())),
+            _ => Err(PatchesParseError::InvalidFileMode(mode.to_owned())),
         }
     }
 }

--- a/src/patches/error.rs
+++ b/src/patches/error.rs
@@ -1,0 +1,22 @@
+//! Error types for patches parsing.
+
+use std::borrow::Cow;
+use std::fmt;
+
+/// An error returned when parsing patches fails.
+#[derive(Debug)]
+pub struct PatchSetParseError(Cow<'static, str>);
+
+impl PatchSetParseError {
+    pub(crate) fn new<E: Into<Cow<'static, str>>>(e: E) -> Self {
+        Self(e.into())
+    }
+}
+
+impl fmt::Display for PatchSetParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "error parsing patchset: {}", self.0)
+    }
+}
+
+impl std::error::Error for PatchSetParseError {}

--- a/src/patches/error.rs
+++ b/src/patches/error.rs
@@ -8,7 +8,7 @@ use crate::patch::ParsePatchError;
 /// An error returned when parsing patches fails.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
-pub enum PatchSetParseError {
+pub enum PatchesParseError {
     /// Single patch parsing failed.
     Patch(ParsePatchError),
 
@@ -40,7 +40,7 @@ pub enum PatchSetParseError {
     CreateMissingModifiedPath,
 }
 
-impl fmt::Display for PatchSetParseError {
+impl fmt::Display for PatchesParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let msg = match self {
             Self::Patch(e) => return write!(f, "error parsing patchset: {e}"),
@@ -65,15 +65,15 @@ impl fmt::Display for PatchSetParseError {
     }
 }
 
-impl std::error::Error for PatchSetParseError {}
+impl std::error::Error for PatchesParseError {}
 
-impl From<ParsePatchError> for PatchSetParseError {
+impl From<ParsePatchError> for PatchesParseError {
     fn from(e: ParsePatchError) -> Self {
         Self::Patch(e)
     }
 }
 
-impl From<BinaryPatchParseError> for PatchSetParseError {
+impl From<BinaryPatchParseError> for PatchesParseError {
     fn from(e: BinaryPatchParseError) -> Self {
         Self::Binary(e)
     }

--- a/src/patches/error.rs
+++ b/src/patches/error.rs
@@ -1,22 +1,80 @@
 //! Error types for patches parsing.
 
-use std::borrow::Cow;
 use std::fmt;
 
-/// An error returned when parsing patches fails.
-#[derive(Debug)]
-pub struct PatchSetParseError(Cow<'static, str>);
+use crate::binary::BinaryPatchParseError;
+use crate::patch::ParsePatchError;
 
-impl PatchSetParseError {
-    pub(crate) fn new<E: Into<Cow<'static, str>>>(e: E) -> Self {
-        Self(e.into())
-    }
+/// An error returned when parsing patches fails.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PatchSetParseError {
+    /// Single patch parsing failed.
+    Patch(ParsePatchError),
+
+    /// Binary patch parsing failed.
+    Binary(BinaryPatchParseError),
+
+    /// No valid patches found in input.
+    NoPatchesFound,
+
+    /// Binary diff not supported with current options.
+    BinaryNotSupported { path: String },
+
+    /// Invalid `diff --git` path.
+    InvalidDiffGitPath,
+
+    /// Invalid file mode.
+    InvalidFileMode(String),
+
+    /// Patch has no file path.
+    NoFilePath,
+
+    /// Patch has both original and modified as /dev/null.
+    BothDevNull,
+
+    /// Delete patch missing original path.
+    DeleteMissingOriginalPath,
+
+    /// Create patch missing modified path.
+    CreateMissingModifiedPath,
 }
 
 impl fmt::Display for PatchSetParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "error parsing patchset: {}", self.0)
+        let msg = match self {
+            Self::Patch(e) => return write!(f, "error parsing patchset: {e}"),
+            Self::Binary(e) => return write!(f, "error parsing patchset: {e}"),
+            Self::NoPatchesFound => "no valid patches found",
+            Self::BinaryNotSupported { path } => {
+                return write!(
+                    f,
+                    "error parsing patchset: binary diff not supported: {path}"
+                )
+            }
+            Self::InvalidDiffGitPath => "unable to parse `diff --git` path",
+            Self::InvalidFileMode(mode) => {
+                return write!(f, "error parsing patchset: invalid file mode: {mode}")
+            }
+            Self::NoFilePath => "patch has no file path",
+            Self::BothDevNull => "patch has both original and modified as /dev/null",
+            Self::DeleteMissingOriginalPath => "delete patch has no original path",
+            Self::CreateMissingModifiedPath => "create patch has no modified path",
+        };
+        write!(f, "error parsing patchset: {msg}")
     }
 }
 
 impl std::error::Error for PatchSetParseError {}
+
+impl From<ParsePatchError> for PatchSetParseError {
+    fn from(e: ParsePatchError) -> Self {
+        Self::Patch(e)
+    }
+}
+
+impl From<BinaryPatchParseError> for PatchSetParseError {
+    fn from(e: BinaryPatchParseError) -> Self {
+        Self::Binary(e)
+    }
+}

--- a/src/patches/parse.rs
+++ b/src/patches/parse.rs
@@ -153,10 +153,8 @@ impl<'a> Patches<'a> {
                     return self.next_gitdiff_patch();
                 }
                 Binary::Fail => {
-                    let path = header.diff_git_line.unwrap_or("<unknown>");
-                    return Some(Err(PatchSetParseError::new(format!(
-                        "binary diff not supported: {path}"
-                    ))));
+                    let path = header.diff_git_line.unwrap_or("<unknown>").to_owned();
+                    return Some(Err(PatchSetParseError::BinaryNotSupported { path }));
                 }
                 Binary::Keep => {
                     let operation = match extract_file_op_binary(&header) {
@@ -185,17 +183,15 @@ impl<'a> Patches<'a> {
                     return self.next_gitdiff_patch();
                 }
                 Binary::Fail => {
-                    let path = header.diff_git_line.unwrap_or("<unknown>");
-                    return Some(Err(PatchSetParseError::new(format!(
-                        "binary diff not supported: {path}"
-                    ))));
+                    let path = header.diff_git_line.unwrap_or("<unknown>").to_owned();
+                    return Some(Err(PatchSetParseError::BinaryNotSupported { path }));
                 }
                 Binary::Keep => {
                     // Find "GIT binary patch" in header and parse from there
                     let binary_start = git_diff.header.find("GIT binary patch").unwrap_or(0);
                     let binary_patch = match parse_binary_patch(&git_diff.header[binary_start..]) {
                         Ok(bp) => bp,
-                        Err(e) => return Some(Err(PatchSetParseError::new(e.to_string()))),
+                        Err(e) => return Some(Err(e.into())),
                     };
                     let operation = match extract_file_op_binary(&header) {
                         Ok(op) => op,
@@ -222,7 +218,7 @@ impl<'a> Patches<'a> {
         } else {
             match parse_one(git_diff.patch) {
                 Ok((patch, _consumed)) => patch,
-                Err(e) => return Some(Err(PatchSetParseError::new(e.to_string()))),
+                Err(e) => return Some(Err(e.into())),
             }
         };
 
@@ -301,7 +297,7 @@ impl<'a> Patches<'a> {
 
         let patch = match parse_one(patch_content) {
             Ok((patch, _consumed)) => patch,
-            Err(e) => return Some(Err(PatchSetParseError::new(e.to_string()))),
+            Err(e) => return Some(Err(e.into())),
         };
 
         let operation = match extract_file_op_unidiff(patch.original_path(), patch.modified_path())
@@ -331,7 +327,7 @@ impl<'a> Iterator for Patches<'a> {
                 if result.is_none() {
                     self.finished = true;
                     if !self.found_any {
-                        return Some(Err(PatchSetParseError::new("no valid patches found")));
+                        return Some(Err(PatchSetParseError::NoPatchesFound));
                     }
                 }
                 result
@@ -341,7 +337,7 @@ impl<'a> Iterator for Patches<'a> {
                 if result.is_none() {
                     self.finished = true;
                     if !self.found_any {
-                        return Some(Err(PatchSetParseError::new("no valid patches found")));
+                        return Some(Err(PatchSetParseError::NoPatchesFound));
                     }
                 }
                 result
@@ -437,18 +433,14 @@ pub fn extract_file_op_unidiff<'a>(
     let is_delete = modified.as_deref() == Some(DEV_NULL);
 
     if is_create && is_delete {
-        return Err(PatchSetParseError::new(
-            "patch has both original and modified as /dev/null",
-        ));
+        return Err(PatchSetParseError::BothDevNull);
     }
 
     if is_delete {
-        let path =
-            original.ok_or_else(|| PatchSetParseError::new("delete patch has no original path"))?;
+        let path = original.ok_or(PatchSetParseError::DeleteMissingOriginalPath)?;
         Ok(FileOperation::Delete(path))
     } else if is_create {
-        let path =
-            modified.ok_or_else(|| PatchSetParseError::new("create patch has no modified path"))?;
+        let path = modified.ok_or(PatchSetParseError::CreateMissingModifiedPath)?;
         Ok(FileOperation::Create(path))
     } else {
         match (original, modified) {
@@ -468,7 +460,7 @@ pub fn extract_file_op_unidiff<'a>(
                     original,
                 })
             }
-            (None, None) => Err(PatchSetParseError::new("patch has no file path")),
+            (None, None) => Err(PatchSetParseError::NoFilePath),
         }
     }
 }
@@ -494,7 +486,7 @@ fn extract_file_op_binary<'a>(
 
     // Use `diff --git <old> <new>` for binary patches.
     let Some((original, modified)) = header.diff_git_line.and_then(parse_diff_git_path) else {
-        return Err(PatchSetParseError::new("unable to parse `diff --git` path"));
+        return Err(PatchSetParseError::InvalidDiffGitPath);
     };
 
     let op = if header.new_file_mode.is_some() {
@@ -550,7 +542,7 @@ fn extract_file_op_gitdiff<'a>(
 
     // Fall back to `diff --git <old> <new>` for mode-only and empty file changes.
     let Some((original, modified)) = header.diff_git_line.and_then(parse_diff_git_path) else {
-        return Err(PatchSetParseError::new("unable to parse `diff --git` path"));
+        return Err(PatchSetParseError::InvalidDiffGitPath);
     };
 
     let op = if header.new_file_mode.is_some() {

--- a/src/patches/parse.rs
+++ b/src/patches/parse.rs
@@ -8,7 +8,7 @@ use super::FileOperation;
 use super::FilePatch;
 use super::Format;
 use super::ParseOptions;
-use super::PatchSetParseError;
+use super::PatchesParseError;
 use crate::binary::parse_binary_patch;
 use crate::patch::parse::parse_one;
 use crate::utils::escaped_filename;
@@ -127,7 +127,7 @@ impl<'a> Patches<'a> {
         None
     }
 
-    fn next_gitdiff_patch(&mut self) -> Option<Result<FilePatch<'a, str>, PatchSetParseError>> {
+    fn next_gitdiff_patch(&mut self) -> Option<Result<FilePatch<'a, str>, PatchesParseError>> {
         // Find next patch start
         let patch_start = self.find_next_gitdiff_start()?;
 
@@ -154,7 +154,7 @@ impl<'a> Patches<'a> {
                 }
                 Binary::Fail => {
                     let path = header.diff_git_line.unwrap_or("<unknown>").to_owned();
-                    return Some(Err(PatchSetParseError::BinaryNotSupported { path }));
+                    return Some(Err(PatchesParseError::BinaryNotSupported { path }));
                 }
                 Binary::Keep => {
                     let operation = match extract_file_op_binary(&header) {
@@ -184,7 +184,7 @@ impl<'a> Patches<'a> {
                 }
                 Binary::Fail => {
                     let path = header.diff_git_line.unwrap_or("<unknown>").to_owned();
-                    return Some(Err(PatchSetParseError::BinaryNotSupported { path }));
+                    return Some(Err(PatchesParseError::BinaryNotSupported { path }));
                 }
                 Binary::Keep => {
                     // Find "GIT binary patch" in header and parse from there
@@ -254,7 +254,7 @@ impl<'a> Patches<'a> {
         Some(Ok(FilePatch::new(operation, patch, old_mode, new_mode)))
     }
 
-    fn next_unidiff_patch(&mut self) -> Option<Result<FilePatch<'a, str>, PatchSetParseError>> {
+    fn next_unidiff_patch(&mut self) -> Option<Result<FilePatch<'a, str>, PatchesParseError>> {
         let remaining = &self.input[self.offset..];
         if remaining.is_empty() {
             return None;
@@ -314,7 +314,7 @@ impl<'a> Patches<'a> {
 }
 
 impl<'a> Iterator for Patches<'a> {
-    type Item = Result<FilePatch<'a, str>, PatchSetParseError>;
+    type Item = Result<FilePatch<'a, str>, PatchesParseError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.finished {
@@ -327,7 +327,7 @@ impl<'a> Iterator for Patches<'a> {
                 if result.is_none() {
                     self.finished = true;
                     if !self.found_any {
-                        return Some(Err(PatchSetParseError::NoPatchesFound));
+                        return Some(Err(PatchesParseError::NoPatchesFound));
                     }
                 }
                 result
@@ -337,7 +337,7 @@ impl<'a> Iterator for Patches<'a> {
                 if result.is_none() {
                     self.finished = true;
                     if !self.found_any {
-                        return Some(Err(PatchSetParseError::NoPatchesFound));
+                        return Some(Err(PatchesParseError::NoPatchesFound));
                     }
                 }
                 result
@@ -428,19 +428,19 @@ fn strip_email_preamble(input: &str) -> &str {
 pub fn extract_file_op_unidiff<'a>(
     original: Option<Cow<'a, str>>,
     modified: Option<Cow<'a, str>>,
-) -> Result<FileOperation<'a>, PatchSetParseError> {
+) -> Result<FileOperation<'a>, PatchesParseError> {
     let is_create = original.as_deref() == Some(DEV_NULL);
     let is_delete = modified.as_deref() == Some(DEV_NULL);
 
     if is_create && is_delete {
-        return Err(PatchSetParseError::BothDevNull);
+        return Err(PatchesParseError::BothDevNull);
     }
 
     if is_delete {
-        let path = original.ok_or(PatchSetParseError::DeleteMissingOriginalPath)?;
+        let path = original.ok_or(PatchesParseError::DeleteMissingOriginalPath)?;
         Ok(FileOperation::Delete(path))
     } else if is_create {
-        let path = modified.ok_or(PatchSetParseError::CreateMissingModifiedPath)?;
+        let path = modified.ok_or(PatchesParseError::CreateMissingModifiedPath)?;
         Ok(FileOperation::Create(path))
     } else {
         match (original, modified) {
@@ -460,7 +460,7 @@ pub fn extract_file_op_unidiff<'a>(
                     original,
                 })
             }
-            (None, None) => Err(PatchSetParseError::NoFilePath),
+            (None, None) => Err(PatchesParseError::NoFilePath),
         }
     }
 }
@@ -469,7 +469,7 @@ pub fn extract_file_op_unidiff<'a>(
 /// Extracts file operation for binary patches (no ---/+++ headers).
 fn extract_file_op_binary<'a>(
     header: &GitHeader<'a>,
-) -> Result<FileOperation<'a>, PatchSetParseError> {
+) -> Result<FileOperation<'a>, PatchesParseError> {
     // Git headers are authoritative for rename/copy
     if let (Some(from), Some(to)) = (header.rename_from, header.rename_to) {
         return Ok(FileOperation::Rename {
@@ -486,7 +486,7 @@ fn extract_file_op_binary<'a>(
 
     // Use `diff --git <old> <new>` for binary patches.
     let Some((original, modified)) = header.diff_git_line.and_then(parse_diff_git_path) else {
-        return Err(PatchSetParseError::InvalidDiffGitPath);
+        return Err(PatchesParseError::InvalidDiffGitPath);
     };
 
     let op = if header.new_file_mode.is_some() {
@@ -503,7 +503,7 @@ fn extract_file_op_binary<'a>(
 /// Parses file modes from git extended headers.
 fn parse_file_modes(
     header: &GitHeader<'_>,
-) -> Result<(Option<FileMode>, Option<FileMode>), PatchSetParseError> {
+) -> Result<(Option<FileMode>, Option<FileMode>), PatchesParseError> {
     let old_mode = header
         .old_mode
         .or(header.deleted_file_mode)
@@ -520,7 +520,7 @@ fn parse_file_modes(
 fn extract_file_op_gitdiff<'a>(
     header: &GitHeader<'a>,
     patch: &Patch<'a, str>,
-) -> Result<FileOperation<'a>, PatchSetParseError> {
+) -> Result<FileOperation<'a>, PatchesParseError> {
     // Git headers are authoritative for rename/copy
     if let (Some(from), Some(to)) = (header.rename_from, header.rename_to) {
         return Ok(FileOperation::Rename {
@@ -542,7 +542,7 @@ fn extract_file_op_gitdiff<'a>(
 
     // Fall back to `diff --git <old> <new>` for mode-only and empty file changes.
     let Some((original, modified)) = header.diff_git_line.and_then(parse_diff_git_path) else {
-        return Err(PatchSetParseError::InvalidDiffGitPath);
+        return Err(PatchesParseError::InvalidDiffGitPath);
     };
 
     let op = if header.new_file_mode.is_some() {

--- a/src/patches/tests.rs
+++ b/src/patches/tests.rs
@@ -3,6 +3,7 @@
 use super::FileMode;
 use super::FileOperation;
 use super::ParseOptions;
+use super::PatchSetParseError;
 use super::Patches;
 
 mod file_operation {
@@ -610,7 +611,7 @@ old mode 100644
 new mode 100755
 ";
         let result: Result<Vec<_>, _> = Patches::parse(content, ParseOptions::gitdiff()).collect();
-        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), PatchSetParseError::InvalidDiffGitPath);
     }
 
     #[test]
@@ -622,7 +623,7 @@ old mode 100644
 new mode 100755
 ";
         let result: Result<Vec<_>, _> = Patches::parse(content, ParseOptions::gitdiff()).collect();
-        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), PatchSetParseError::InvalidDiffGitPath);
     }
 
     #[test]
@@ -826,9 +827,10 @@ Binary files a/image.png and b/image.png differ
         let result: Result<Vec<_>, _> =
             Patches::parse(content, ParseOptions::gitdiff().fail_on_binary()).collect();
 
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err.to_string().contains("binary"));
+        assert!(matches!(
+            result.unwrap_err(),
+            PatchSetParseError::BinaryNotSupported { .. }
+        ));
     }
 
     #[test]
@@ -847,7 +849,10 @@ Binary files a/binary.bin and b/binary.bin differ
         let result: Result<Vec<_>, _> =
             Patches::parse(content, ParseOptions::gitdiff().fail_on_binary()).collect();
 
-        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            PatchSetParseError::BinaryNotSupported { .. }
+        ));
     }
 
     #[test]
@@ -1245,7 +1250,7 @@ No patches here
 +new
 ";
         let result: Result<Vec<_>, _> = Patches::parse(content, ParseOptions::unidiff()).collect();
-        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), PatchSetParseError::BothDevNull);
     }
 
     #[test]

--- a/src/patches/tests.rs
+++ b/src/patches/tests.rs
@@ -3,8 +3,8 @@
 use super::FileMode;
 use super::FileOperation;
 use super::ParseOptions;
-use super::PatchSetParseError;
 use super::Patches;
+use super::PatchesParseError;
 
 mod file_operation {
     use super::*;
@@ -611,7 +611,7 @@ old mode 100644
 new mode 100755
 ";
         let result: Result<Vec<_>, _> = Patches::parse(content, ParseOptions::gitdiff()).collect();
-        assert_eq!(result.unwrap_err(), PatchSetParseError::InvalidDiffGitPath);
+        assert_eq!(result.unwrap_err(), PatchesParseError::InvalidDiffGitPath);
     }
 
     #[test]
@@ -623,7 +623,7 @@ old mode 100644
 new mode 100755
 ";
         let result: Result<Vec<_>, _> = Patches::parse(content, ParseOptions::gitdiff()).collect();
-        assert_eq!(result.unwrap_err(), PatchSetParseError::InvalidDiffGitPath);
+        assert_eq!(result.unwrap_err(), PatchesParseError::InvalidDiffGitPath);
     }
 
     #[test]
@@ -829,7 +829,7 @@ Binary files a/image.png and b/image.png differ
 
         assert!(matches!(
             result.unwrap_err(),
-            PatchSetParseError::BinaryNotSupported { .. }
+            PatchesParseError::BinaryNotSupported { .. }
         ));
     }
 
@@ -851,7 +851,7 @@ Binary files a/binary.bin and b/binary.bin differ
 
         assert!(matches!(
             result.unwrap_err(),
-            PatchSetParseError::BinaryNotSupported { .. }
+            PatchesParseError::BinaryNotSupported { .. }
         ));
     }
 
@@ -1250,7 +1250,7 @@ No patches here
 +new
 ";
         let result: Result<Vec<_>, _> = Patches::parse(content, ParseOptions::unidiff()).collect();
-        assert_eq!(result.unwrap_err(), PatchSetParseError::BothDevNull);
+        assert_eq!(result.unwrap_err(), PatchesParseError::BothDevNull);
     }
 
     #[test]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -252,7 +252,7 @@ pub(crate) fn escaped_filename<T: Text + ToOwned + ?Sized>(
         // No need to escape
         let bytes = filename.as_bytes();
         if bytes.iter().any(|b| ESCAPED_CHARS_BYTES.contains(b)) {
-            return Err(ParsePatchError::new("invalid char in unquoted filename"));
+            return Err(ParsePatchError::InvalidCharInUnquotedFilename);
         }
         Ok(bytes.into())
     }
@@ -274,7 +274,7 @@ fn _escaped_filename<T: Text + ToOwned + ?Sized>(
 
             i += 1;
             if i >= bytes.len() {
-                return Err(ParsePatchError::new("expected escaped character"));
+                return Err(ParsePatchError::ExpectedEscapedChar);
             }
 
             let decoded = match bytes[i] {
@@ -284,13 +284,13 @@ fn _escaped_filename<T: Text + ToOwned + ?Sized>(
                 b'r' => b'\r',
                 b'\"' => b'\"',
                 b'\\' => b'\\',
-                _ => return Err(ParsePatchError::new("invalid escaped character")),
+                _ => return Err(ParsePatchError::InvalidEscapedChar),
             };
             result.push(decoded);
             i += 1;
             last_copy = i;
         } else if ESCAPED_CHARS_BYTES.contains(&bytes[i]) {
-            return Err(ParsePatchError::new("invalid unescaped character"));
+            return Err(ParsePatchError::InvalidUnescapedChar);
         } else {
             i += 1;
         }

--- a/tests/compat/common.rs
+++ b/tests/compat/common.rs
@@ -13,8 +13,8 @@ use diffy::binary::BinaryPatchParseError;
 use diffy::patches::FileOperation;
 use diffy::patches::ParseOptions;
 use diffy::patches::PatchKind;
-use diffy::patches::PatchSetParseError;
 use diffy::patches::Patches;
+use diffy::patches::PatchesParseError;
 
 /// Which external tool to compare against.
 #[derive(Clone, Copy)]
@@ -269,7 +269,7 @@ fn print_patch_version() {
 /// Error type for compat tests.
 #[derive(Debug)]
 pub enum TestError {
-    Parse(PatchSetParseError),
+    Parse(PatchesParseError),
     Apply(diffy::ApplyError),
     Binary(BinaryPatchParseError),
 }


### PR DESCRIPTION
Including

* `ParsePatchError`
* `BinaryPatchParseError`
* `PatchSetParseError`