### PR TITLE
feat(patches): add format auto-detection

### DIFF
--- a/src/patches.rs
+++ b/src/patches.rs
@@ -25,6 +25,8 @@ pub(crate) enum Format {
     UniDiff,
     /// Git extended diff format.
     GitDiff,
+    /// Auto-detect format from content.
+    Auto,
 }
 
 /// How to handle binary diffs.
@@ -121,6 +123,14 @@ impl ParseOptions {
     pub fn gitdiff() -> Self {
         Self {
             format: Format::GitDiff,
+            binary: Default::default(),
+        }
+    }
+
+    /// Auto-detect format from patch content.
+    pub fn auto() -> Self {
+        Self {
+            format: Format::Auto,
             binary: Default::default(),
         }
     }

--- a/src/patches/parse.rs
+++ b/src/patches/parse.rs
@@ -368,6 +368,24 @@ impl<'a> Iterator for Patches<'a> {
                 }
                 result
             }
+            Format::Auto => {
+                let result = self.next_gitdiff_patch();
+                if result.is_some() {
+                    self.opts.format = Format::GitDiff;
+                    result
+                } else {
+                    self.offset = 0; // Reset to scan from start
+                    self.opts.format = Format::UniDiff;
+                    let result = self.next_unidiff_patch();
+                    if result.is_none() {
+                        self.finished = true;
+                        if !self.found_any {
+                            return Some(Err(self.error(PatchesParseErrorKind::NoPatchesFound)));
+                        }
+                    }
+                    result
+                }
+            }
         };
 
         // Attach input to errors for richer display

--- a/src/patches/tests.rs
+++ b/src/patches/tests.rs
@@ -1456,6 +1456,109 @@ In a hole in the ground there lived a hobbit
     }
 }
 
+/// Tests documenting the behavior of gitdiff vs unidiff mode when given
+/// content in the "wrong" format.
+mod format_behavior {
+    use super::*;
+
+    /// gitdiff mode fails when given pure unified diff (no `diff --git` marker).
+    /// This is expected - gitdiff mode requires the `diff --git` header.
+    #[test]
+    fn gitdiff_mode_on_unified_content_fails() {
+        let unified = "\
+--- a/file.rs
++++ b/file.rs
+@@ -1 +1 @@
+-old
++new
+";
+        let result: Result<Vec<_>, _> = Patches::parse(unified, ParseOptions::gitdiff()).collect();
+        let err = result.unwrap_err();
+        assert!(matches!(err.kind, PatchesParseErrorKind::NoPatchesFound));
+    }
+
+    /// unidiff mode can parse git diff content (the `diff --git` line is ignored
+    /// as preamble, and `---`/`+++` lines are used as patch boundaries).
+    #[test]
+    fn unidiff_mode_on_gitdiff_content_works() {
+        let gitdiff = "\
+diff --git a/file.rs b/file.rs
+--- a/file.rs
++++ b/file.rs
+@@ -1 +1 @@
+-old
++new
+";
+        let patches: Vec<_> = Patches::parse(gitdiff, ParseOptions::unidiff())
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(patches.len(), 1);
+    }
+
+    /// unidiff mode loses git-specific metadata like mode changes.
+    /// The patch is still parsed but mode information is not available.
+    #[test]
+    fn unidiff_mode_loses_mode_changes() {
+        let gitdiff = "\
+diff --git a/script.sh b/script.sh
+old mode 100644
+new mode 100755
+--- a/script.sh
++++ b/script.sh
+@@ -1 +1 @@
+-old
++new
+";
+        let patches: Vec<_> = Patches::parse(gitdiff, ParseOptions::unidiff())
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(patches.len(), 1);
+        // Mode information is lost in unidiff mode
+        assert_eq!(patches[0].old_mode(), None);
+        assert_eq!(patches[0].new_mode(), None);
+    }
+
+    /// unidiff mode cannot parse pure rename operations (no hunks).
+    /// A pure rename in git has no `---`/`+++` lines, so unidiff mode doesn't see it.
+    #[test]
+    fn unidiff_mode_misses_pure_rename() {
+        let gitdiff = "\
+diff --git a/old.txt b/new.txt
+similarity index 100%
+rename from old.txt
+rename to new.txt
+";
+        let result: Result<Vec<_>, _> = Patches::parse(gitdiff, ParseOptions::unidiff()).collect();
+        let err = result.unwrap_err();
+        // No `---`/`+++` boundary means no patch found
+        assert!(matches!(err.kind, PatchesParseErrorKind::NoPatchesFound));
+    }
+
+    /// unidiff mode can parse git format-patch output (email headers are stripped
+    /// as preamble).
+    #[test]
+    fn unidiff_mode_on_format_patch_content_works() {
+        let format_patch = "\
+From abc123 Mon Sep 17 00:00:00 2001
+From: User <user@example.com>
+Subject: [PATCH] Fix something
+---
+ file.rs | 1 +
+
+diff --git a/file.rs b/file.rs
+--- a/file.rs
++++ b/file.rs
+@@ -1 +1 @@
+-old
++new
+";
+        let patches: Vec<_> = Patches::parse(format_patch, ParseOptions::unidiff())
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(patches.len(), 1);
+    }
+}
+
 mod error_display {
     use super::*;
     use crate::patch::error::ParsePatchErrorKind;

--- a/src/patches/tests.rs
+++ b/src/patches/tests.rs
@@ -1457,7 +1457,7 @@ In a hole in the ground there lived a hobbit
 }
 
 /// Tests documenting the behavior of gitdiff vs unidiff mode when given
-/// content in the "wrong" format.
+/// content in the "wrong" format, and auto-detect mode.
 mod format_behavior {
     use super::*;
 
@@ -1556,6 +1556,144 @@ diff --git a/file.rs b/file.rs
             .collect::<Result<_, _>>()
             .unwrap();
         assert_eq!(patches.len(), 1);
+    }
+
+    /// auto mode detects and uses gitdiff for git diff content.
+    #[test]
+    fn auto_mode_on_gitdiff_content() {
+        let gitdiff = "\
+diff --git a/file.rs b/file.rs
+--- a/file.rs
++++ b/file.rs
+@@ -1 +1 @@
+-old
++new
+";
+        let patches: Vec<_> = Patches::parse(gitdiff, ParseOptions::auto())
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(patches.len(), 1);
+    }
+
+    /// auto mode falls back to unidiff when no `diff --git` marker.
+    #[test]
+    fn auto_mode_on_unified_content() {
+        let unified = "\
+--- a/file.rs
++++ b/file.rs
+@@ -1 +1 @@
+-old
++new
+";
+        let patches: Vec<_> = Patches::parse(unified, ParseOptions::auto())
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(patches.len(), 1);
+    }
+
+    /// auto mode handles git format-patch with email preamble.
+    #[test]
+    fn auto_mode_on_format_patch() {
+        let format_patch = "\
+From abc123 Mon Sep 17 00:00:00 2001
+From: User <user@example.com>
+Subject: [PATCH] Fix something
+---
+ file.rs | 1 +
+
+diff --git a/file.rs b/file.rs
+--- a/file.rs
++++ b/file.rs
+@@ -1 +1 @@
+-old
++new
+";
+        let patches: Vec<_> = Patches::parse(format_patch, ParseOptions::auto())
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(patches.len(), 1);
+    }
+
+    /// auto mode preserves git-specific metadata (mode changes) when using gitdiff.
+    #[test]
+    fn auto_mode_preserves_mode_changes() {
+        let gitdiff = "\
+diff --git a/script.sh b/script.sh
+old mode 100644
+new mode 100755
+--- a/script.sh
++++ b/script.sh
+@@ -1 +1 @@
+-old
++new
+";
+        let patches: Vec<_> = Patches::parse(gitdiff, ParseOptions::auto())
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(patches.len(), 1);
+        // Mode information is preserved in auto mode (uses gitdiff)
+        assert_eq!(patches[0].old_mode(), Some(&FileMode::Regular));
+        assert_eq!(patches[0].new_mode(), Some(&FileMode::Executable));
+    }
+
+    /// auto mode can parse pure rename (only possible via gitdiff detection).
+    #[test]
+    fn auto_mode_handles_pure_rename() {
+        let gitdiff = "\
+diff --git a/old.txt b/new.txt
+similarity index 100%
+rename from old.txt
+rename to new.txt
+";
+        let patches: Vec<_> = Patches::parse(gitdiff, ParseOptions::auto())
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(patches.len(), 1);
+        assert!(patches[0].operation().is_rename());
+    }
+
+    /// auto mode handles multiple patches in git diff format.
+    #[test]
+    fn auto_mode_multi_file_gitdiff() {
+        let gitdiff = "\
+diff --git a/file1.rs b/file1.rs
+--- a/file1.rs
++++ b/file1.rs
+@@ -1 +1 @@
+-old1
++new1
+diff --git a/file2.rs b/file2.rs
+--- a/file2.rs
++++ b/file2.rs
+@@ -1 +1 @@
+-old2
++new2
+";
+        let patches: Vec<_> = Patches::parse(gitdiff, ParseOptions::auto())
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(patches.len(), 2);
+    }
+
+    /// auto mode handles multiple patches in unified diff format.
+    #[test]
+    fn auto_mode_multi_file_unified() {
+        let unified = "\
+--- a/file1.rs
++++ b/file1.rs
+@@ -1 +1 @@
+-old1
++new1
+--- a/file2.rs
++++ b/file2.rs
+@@ -1 +1 @@
+-old2
++new2
+";
+        let patches: Vec<_> = Patches::parse(unified, ParseOptions::auto())
+            .collect::<Result<_, _>>()
+            .unwrap();
+        assert_eq!(patches.len(), 2);
     }
 }
 

--- a/tests/replay.rs
+++ b/tests/replay.rs
@@ -86,18 +86,6 @@ enum CommitSelection {
     Range { from: String, to: String },
 }
 
-/// Strip the first `n` path components from a path.
-fn strip_path_prefix(path: &str, n: usize) -> String {
-    let mut remaining = path;
-    for _ in 0..n {
-        match remaining.split_once('/') {
-            Some((_first, rest)) => remaining = rest,
-            None => return remaining.to_owned(),
-        }
-    }
-    remaining.to_owned()
-}
-
 /// Result of processing a single commit pair.
 struct CommitResult {
     parent_short: String,
@@ -343,45 +331,39 @@ fn process_commit(repo: &PathBuf, parent: &str, child: &str, mode: TestMode) -> 
         // Paths from ---/+++ headers have a/b prefixes that need stripping.
         // Paths from git extended headers (rename/copy) are already clean.
         let operation = file_patch.operation();
+        let strip = match &operation {
+            FileOperation::Rename { .. } | FileOperation::Copy { .. } => 0,
+            _ => 1,
+        };
+        let operation = operation.strip_prefix(strip);
 
-        // Extract path info from operation. Returns (base_path, target_path, desc, strip_prefix).
-        // strip_prefix is 1 for ---/+++ paths (have a/b prefix), 0 for git header paths.
-        let (base_path, target_path, desc, strip): (Option<&str>, Option<&str>, _, _) =
-            match operation {
-                FileOperation::Create(path) => {
-                    (None, Some(path.as_ref()), format!("create {path}"), 1)
-                }
-                FileOperation::Delete(path) => {
-                    (Some(path.as_ref()), None, format!("delete {path}"), 1)
-                }
-                FileOperation::Modify { original, modified } => {
-                    let desc = if original == modified {
-                        format!("modify {original}")
-                    } else {
-                        format!("modify {original} -> {modified}")
-                    };
-                    (Some(original.as_ref()), Some(modified.as_ref()), desc, 1)
-                }
-                // Rename/Copy paths come from git headers WITHOUT a/b prefix
-                FileOperation::Rename { from, to } => (
-                    Some(from.as_ref()),
-                    Some(to.as_ref()),
-                    format!("rename {from} -> {to}"),
-                    0,
-                ),
-                FileOperation::Copy { from, to } => (
-                    Some(from.as_ref()),
-                    Some(to.as_ref()),
-                    format!("copy {from} -> {to}"),
-                    0,
-                ),
-            };
+        let (base_path, target_path, desc): (Option<&str>, Option<&str>, _) = match &operation {
+            FileOperation::Create(path) => (None, Some(path.as_ref()), format!("create {path}")),
+            FileOperation::Delete(path) => (Some(path.as_ref()), None, format!("delete {path}")),
+            FileOperation::Modify { original, modified } => {
+                let desc = if original == modified {
+                    format!("modify {original}")
+                } else {
+                    format!("modify {original} -> {modified}")
+                };
+                (Some(original.as_ref()), Some(modified.as_ref()), desc)
+            }
+            FileOperation::Rename { from, to } => (
+                Some(from.as_ref()),
+                Some(to.as_ref()),
+                format!("rename {from} -> {to}"),
+            ),
+            FileOperation::Copy { from, to } => (
+                Some(from.as_ref()),
+                Some(to.as_ref()),
+                format!("copy {from} -> {to}"),
+            ),
+        };
 
         match file_patch.patch() {
             PatchKind::Text(patch) => {
                 let base_content = if let Some(path) = base_path {
-                    let path = strip_path_prefix(path, strip);
-                    let Some(content) = file_at_commit(repo, parent, &path) else {
+                    let Some(content) = file_at_commit(repo, parent, path) else {
                         skipped += 1;
                         continue;
                     };
@@ -391,8 +373,7 @@ fn process_commit(repo: &PathBuf, parent: &str, child: &str, mode: TestMode) -> 
                 };
 
                 let expected_content = if let Some(path) = target_path {
-                    let path = strip_path_prefix(path, strip);
-                    let Some(content) = file_at_commit(repo, child, &path) else {
+                    let Some(content) = file_at_commit(repo, child, path) else {
                         skipped += 1;
                         continue;
                     };
@@ -429,8 +410,7 @@ fn process_commit(repo: &PathBuf, parent: &str, child: &str, mode: TestMode) -> 
             PatchKind::Binary(patch) => {
                 // Get content as bytes
                 let base_content = if let Some(path) = base_path {
-                    let path = strip_path_prefix(path, strip);
-                    let Some(content) = file_at_commit_bytes(repo, parent, &path) else {
+                    let Some(content) = file_at_commit_bytes(repo, parent, path) else {
                         skipped += 1;
                         continue;
                     };
@@ -440,8 +420,7 @@ fn process_commit(repo: &PathBuf, parent: &str, child: &str, mode: TestMode) -> 
                 };
 
                 let expected_content = if let Some(path) = target_path {
-                    let path = strip_path_prefix(path, strip);
-                    let Some(content) = file_at_commit_bytes(repo, child, &path) else {
+                    let Some(content) = file_at_commit_bytes(repo, child, path) else {
                         skipped += 1;
                         continue;
                     };


### PR DESCRIPTION
Add `Format::Auto` variant that auto-detects patch format:

- Tries git diff format first (looking for `diff --git` headers)
- Falls back to unified diff format if no git diff patches found
- Once format is detected, commits to that mode for subsequent patches

This is the recommended default for most use cases,
as it handles both formats transparently
while preserving git-specific metadata when available.
